### PR TITLE
chore: set go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/agynio/llm
 
-go 1.25.7
+go 1.25
 
 require (
 	google.golang.org/grpc v1.79.2


### PR DESCRIPTION
## Summary
- align go.mod directive with Go 1.25

## Testing
- go vet ./...
- go build ./...
- go test ./...

## Issue
Refs #1