### PR TITLE
feat: implement grpc server and proxy

### DIFF
--- a/cmd/llm/main.go
+++ b/cmd/llm/main.go
@@ -1,3 +1,120 @@
 package main
 
-func main() {}
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	llmv1 "github.com/agynio/llm/gen/go/agynio/api/llm/v1"
+	"github.com/agynio/llm/internal/config"
+	"github.com/agynio/llm/internal/db"
+	"github.com/agynio/llm/internal/grpcserver"
+	"github.com/agynio/llm/internal/model"
+	"github.com/agynio/llm/internal/provider"
+	"github.com/agynio/llm/internal/proxy"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"google.golang.org/grpc"
+)
+
+const shutdownTimeout = 10 * time.Second
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("llm: %v", err)
+	}
+}
+
+func run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cfg, err := config.FromEnv()
+	if err != nil {
+		return err
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("parse database url: %w", err)
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return fmt.Errorf("create connection pool: %w", err)
+	}
+	defer pool.Close()
+
+	if err := db.ApplyMigrations(ctx, pool); err != nil {
+		return fmt.Errorf("apply migrations: %w", err)
+	}
+
+	providerStore := provider.NewStore(pool)
+	modelStore := model.NewStore(pool)
+	resolver := proxy.NewResolver(providerStore, modelStore)
+	proxyService := proxy.NewService(resolver, &http.Client{})
+
+	grpcServer := grpc.NewServer()
+	llmv1.RegisterLLMServiceServer(grpcServer, grpcserver.New(providerStore, modelStore, proxyService))
+
+	grpcListener, err := net.Listen("tcp", cfg.GRPCAddress)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", cfg.GRPCAddress, err)
+	}
+
+	httpServer := &http.Server{
+		Addr:    cfg.HTTPAddress,
+		Handler: proxy.NewHandler(proxyService),
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		log.Printf("LLM gRPC listening on %s", cfg.GRPCAddress)
+		if err := grpcServer.Serve(grpcListener); err != nil {
+			if errors.Is(err, grpc.ErrServerStopped) {
+				return
+			}
+			errCh <- fmt.Errorf("serve grpc: %w", err)
+		}
+	}()
+
+	go func() {
+		log.Printf("LLM HTTP listening on %s", cfg.HTTPAddress)
+		if err := httpServer.ListenAndServe(); err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				return
+			}
+			errCh <- fmt.Errorf("serve http: %w", err)
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+	case err := <-errCh:
+		return err
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shutdown http: %w", err)
+	}
+
+	grpcDone := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(grpcDone)
+	}()
+	select {
+	case <-grpcDone:
+	case <-shutdownCtx.Done():
+		grpcServer.Stop()
+	}
+	return nil
+}

--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -1,0 +1,432 @@
+package grpcserver
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+
+	llmv1 "github.com/agynio/llm/gen/go/agynio/api/llm/v1"
+	"github.com/agynio/llm/internal/model"
+	"github.com/agynio/llm/internal/provider"
+	"github.com/agynio/llm/internal/proxy"
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type ProviderStore interface {
+	Create(ctx context.Context, input provider.CreateInput) (provider.Provider, error)
+	Get(ctx context.Context, id uuid.UUID) (provider.Provider, error)
+	Update(ctx context.Context, input provider.UpdateInput) (provider.Provider, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	List(ctx context.Context, pageSize int32, cursor *provider.PageCursor) (provider.ListResult, error)
+}
+
+type ModelStore interface {
+	Create(ctx context.Context, input model.CreateInput) (model.Model, error)
+	Get(ctx context.Context, id uuid.UUID) (model.Model, error)
+	Update(ctx context.Context, input model.UpdateInput) (model.Model, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	List(ctx context.Context, filter model.ListFilter, pageSize int32, cursor *model.PageCursor) (model.ListResult, error)
+}
+
+type Proxy interface {
+	CreateResponse(ctx context.Context, modelID uuid.UUID, body []byte) (proxy.Response, error)
+	CreateResponseStream(ctx context.Context, modelID uuid.UUID, body []byte) (proxy.StreamResponse, error)
+}
+
+type Server struct {
+	llmv1.UnimplementedLLMServiceServer
+	providers ProviderStore
+	models    ModelStore
+	proxy     Proxy
+}
+
+func New(providers ProviderStore, models ModelStore, proxyClient Proxy) *Server {
+	return &Server{providers: providers, models: models, proxy: proxyClient}
+}
+
+func (s *Server) CreateLLMProvider(ctx context.Context, req *llmv1.CreateLLMProviderRequest) (*llmv1.CreateLLMProviderResponse, error) {
+	endpoint := strings.TrimSpace(req.GetEndpoint())
+	if endpoint == "" {
+		return nil, status.Error(codes.InvalidArgument, "endpoint is required")
+	}
+	token := strings.TrimSpace(req.GetToken())
+	if token == "" {
+		return nil, status.Error(codes.InvalidArgument, "token is required")
+	}
+	authMethod, err := parseAuthMethod(req.GetAuthMethod(), true)
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := s.providers.Create(ctx, provider.CreateInput{
+		Endpoint:   endpoint,
+		AuthMethod: authMethod,
+		Token:      token,
+	})
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	return &llmv1.CreateLLMProviderResponse{Provider: toProtoProvider(created)}, nil
+}
+
+func (s *Server) GetLLMProvider(ctx context.Context, req *llmv1.GetLLMProviderRequest) (*llmv1.GetLLMProviderResponse, error) {
+	id, err := parseUUID(req.GetId(), "id")
+	if err != nil {
+		return nil, err
+	}
+	prov, err := s.providers.Get(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &llmv1.GetLLMProviderResponse{Provider: toProtoProvider(prov)}, nil
+}
+
+func (s *Server) UpdateLLMProvider(ctx context.Context, req *llmv1.UpdateLLMProviderRequest) (*llmv1.UpdateLLMProviderResponse, error) {
+	id, err := parseUUID(req.GetId(), "id")
+	if err != nil {
+		return nil, err
+	}
+
+	input := provider.UpdateInput{ID: id}
+	if req.Endpoint != nil {
+		endpoint := strings.TrimSpace(req.GetEndpoint())
+		if endpoint == "" {
+			return nil, status.Error(codes.InvalidArgument, "endpoint cannot be empty")
+		}
+		input.Endpoint = &endpoint
+	}
+	if req.AuthMethod != nil {
+		method, err := parseAuthMethod(req.GetAuthMethod(), false)
+		if err != nil {
+			return nil, err
+		}
+		input.AuthMethod = &method
+	}
+	if req.Token != nil {
+		token := strings.TrimSpace(req.GetToken())
+		if token == "" {
+			return nil, status.Error(codes.InvalidArgument, "token cannot be empty")
+		}
+		input.Token = &token
+	}
+
+	updated, err := s.providers.Update(ctx, input)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	return &llmv1.UpdateLLMProviderResponse{Provider: toProtoProvider(updated)}, nil
+}
+
+func (s *Server) DeleteLLMProvider(ctx context.Context, req *llmv1.DeleteLLMProviderRequest) (*llmv1.DeleteLLMProviderResponse, error) {
+	id, err := parseUUID(req.GetId(), "id")
+	if err != nil {
+		return nil, err
+	}
+	if err := s.providers.Delete(ctx, id); err != nil {
+		return nil, toStatusError(err)
+	}
+	return &llmv1.DeleteLLMProviderResponse{}, nil
+}
+
+func (s *Server) ListLLMProviders(ctx context.Context, req *llmv1.ListLLMProvidersRequest) (*llmv1.ListLLMProvidersResponse, error) {
+	var cursor *provider.PageCursor
+	if req.GetPageToken() != "" {
+		decoded, err := provider.DecodePageToken(req.GetPageToken())
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid page_token")
+		}
+		cursor = &decoded
+	}
+
+	result, err := s.providers.List(ctx, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	providers := make([]*llmv1.LLMProvider, 0, len(result.Providers))
+	for _, prov := range result.Providers {
+		providers = append(providers, toProtoProvider(prov))
+	}
+
+	resp := &llmv1.ListLLMProvidersResponse{Providers: providers}
+	if result.NextCursor != nil {
+		token, err := provider.EncodePageToken(*result.NextCursor)
+		if err != nil {
+			return nil, status.Error(codes.Internal, "failed to encode page token")
+		}
+		resp.NextPageToken = token
+	}
+
+	return resp, nil
+}
+
+func (s *Server) CreateModel(ctx context.Context, req *llmv1.CreateModelRequest) (*llmv1.CreateModelResponse, error) {
+	name := strings.TrimSpace(req.GetName())
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "name is required")
+	}
+	providerID, err := parseUUID(req.GetLlmProviderId(), "llm_provider_id")
+	if err != nil {
+		return nil, err
+	}
+	remoteName := strings.TrimSpace(req.GetRemoteName())
+	if remoteName == "" {
+		return nil, status.Error(codes.InvalidArgument, "remote_name is required")
+	}
+
+	created, err := s.models.Create(ctx, model.CreateInput{
+		Name:       name,
+		ProviderID: providerID,
+		RemoteName: remoteName,
+	})
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	return &llmv1.CreateModelResponse{Model: toProtoModel(created)}, nil
+}
+
+func (s *Server) GetModel(ctx context.Context, req *llmv1.GetModelRequest) (*llmv1.GetModelResponse, error) {
+	id, err := parseUUID(req.GetId(), "id")
+	if err != nil {
+		return nil, err
+	}
+	mdl, err := s.models.Get(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &llmv1.GetModelResponse{Model: toProtoModel(mdl)}, nil
+}
+
+func (s *Server) UpdateModel(ctx context.Context, req *llmv1.UpdateModelRequest) (*llmv1.UpdateModelResponse, error) {
+	id, err := parseUUID(req.GetId(), "id")
+	if err != nil {
+		return nil, err
+	}
+	input := model.UpdateInput{ID: id}
+
+	if req.Name != nil {
+		name := strings.TrimSpace(req.GetName())
+		if name == "" {
+			return nil, status.Error(codes.InvalidArgument, "name cannot be empty")
+		}
+		input.Name = &name
+	}
+	if req.LlmProviderId != nil {
+		providerID, err := parseUUID(req.GetLlmProviderId(), "llm_provider_id")
+		if err != nil {
+			return nil, err
+		}
+		input.ProviderID = &providerID
+	}
+	if req.RemoteName != nil {
+		remoteName := strings.TrimSpace(req.GetRemoteName())
+		if remoteName == "" {
+			return nil, status.Error(codes.InvalidArgument, "remote_name cannot be empty")
+		}
+		input.RemoteName = &remoteName
+	}
+
+	updated, err := s.models.Update(ctx, input)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &llmv1.UpdateModelResponse{Model: toProtoModel(updated)}, nil
+}
+
+func (s *Server) DeleteModel(ctx context.Context, req *llmv1.DeleteModelRequest) (*llmv1.DeleteModelResponse, error) {
+	id, err := parseUUID(req.GetId(), "id")
+	if err != nil {
+		return nil, err
+	}
+	if err := s.models.Delete(ctx, id); err != nil {
+		return nil, toStatusError(err)
+	}
+	return &llmv1.DeleteModelResponse{}, nil
+}
+
+func (s *Server) ListModels(ctx context.Context, req *llmv1.ListModelsRequest) (*llmv1.ListModelsResponse, error) {
+	filter := model.ListFilter{}
+	if req.GetLlmProviderId() != "" {
+		providerID, err := parseUUID(req.GetLlmProviderId(), "llm_provider_id")
+		if err != nil {
+			return nil, err
+		}
+		filter.ProviderID = &providerID
+	}
+
+	var cursor *model.PageCursor
+	if req.GetPageToken() != "" {
+		decoded, tokenProviderID, err := model.DecodePageToken(req.GetPageToken())
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid page_token")
+		}
+		cursor = &decoded
+		if tokenProviderID != nil {
+			if filter.ProviderID == nil {
+				filter.ProviderID = tokenProviderID
+			} else if *filter.ProviderID != *tokenProviderID {
+				return nil, status.Error(codes.InvalidArgument, "page_token does not match llm_provider_id")
+			}
+		}
+	}
+
+	result, err := s.models.List(ctx, filter, req.GetPageSize(), cursor)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	models := make([]*llmv1.Model, 0, len(result.Models))
+	for _, mdl := range result.Models {
+		models = append(models, toProtoModel(mdl))
+	}
+
+	resp := &llmv1.ListModelsResponse{Models: models}
+	if result.NextCursor != nil {
+		token, err := model.EncodePageToken(*result.NextCursor, filter.ProviderID)
+		if err != nil {
+			return nil, status.Error(codes.Internal, "failed to encode page token")
+		}
+		resp.NextPageToken = token
+	}
+
+	return resp, nil
+}
+
+func (s *Server) CreateResponse(ctx context.Context, req *llmv1.CreateResponseRequest) (*llmv1.CreateResponseResponse, error) {
+	modelID, err := parseUUID(req.GetModelId(), "model_id")
+	if err != nil {
+		return nil, err
+	}
+	if len(req.GetBody()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "body is required")
+	}
+
+	resp, err := s.proxy.CreateResponse(ctx, modelID, req.GetBody())
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, status.Errorf(codes.Internal, "provider response status %d: %s", resp.StatusCode, strings.TrimSpace(string(resp.Body)))
+	}
+	return &llmv1.CreateResponseResponse{Body: resp.Body}, nil
+}
+
+func (s *Server) CreateResponseStream(req *llmv1.CreateResponseStreamRequest, stream llmv1.LLMService_CreateResponseStreamServer) error {
+	modelID, err := parseUUID(req.GetModelId(), "model_id")
+	if err != nil {
+		return err
+	}
+	if len(req.GetBody()) == 0 {
+		return status.Error(codes.InvalidArgument, "body is required")
+	}
+
+	resp, err := s.proxy.CreateResponseStream(stream.Context(), modelID, req.GetBody())
+	if err != nil {
+		return toStatusError(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return status.Errorf(codes.Internal, "provider response status %d", resp.StatusCode)
+		}
+		return status.Errorf(codes.Internal, "provider response status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return proxy.ReadSSE(stream.Context(), resp.Body, func(event proxy.Event) error {
+		return stream.Send(&llmv1.CreateResponseStreamResponse{
+			EventType: event.EventType,
+			Data:      event.Data,
+		})
+	})
+}
+
+func parseUUID(value string, field string) (uuid.UUID, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return uuid.Nil, status.Errorf(codes.InvalidArgument, "%s is required", field)
+	}
+	id, err := uuid.Parse(trimmed)
+	if err != nil {
+		return uuid.Nil, status.Errorf(codes.InvalidArgument, "%s must be a valid UUID", field)
+	}
+	return id, nil
+}
+
+func parseAuthMethod(value llmv1.AuthMethod, allowUnspecified bool) (provider.AuthMethod, error) {
+	switch value {
+	case llmv1.AuthMethod_AUTH_METHOD_BEARER:
+		return provider.AuthMethodBearer, nil
+	case llmv1.AuthMethod_AUTH_METHOD_UNSPECIFIED:
+		if allowUnspecified {
+			return provider.AuthMethodBearer, nil
+		}
+		return "", status.Error(codes.InvalidArgument, "auth_method must be set")
+	default:
+		return "", status.Error(codes.InvalidArgument, "auth_method is invalid")
+	}
+}
+
+func toProtoProvider(prov provider.Provider) *llmv1.LLMProvider {
+	return &llmv1.LLMProvider{
+		Meta: &llmv1.EntityMeta{
+			Id:        prov.ID.String(),
+			CreatedAt: timestamppb.New(prov.CreatedAt),
+			UpdatedAt: timestamppb.New(prov.UpdatedAt),
+		},
+		Endpoint:   prov.Endpoint,
+		AuthMethod: toProtoAuthMethod(prov.AuthMethod),
+	}
+}
+
+func toProtoModel(mdl model.Model) *llmv1.Model {
+	return &llmv1.Model{
+		Meta: &llmv1.EntityMeta{
+			Id:        mdl.ID.String(),
+			CreatedAt: timestamppb.New(mdl.CreatedAt),
+			UpdatedAt: timestamppb.New(mdl.UpdatedAt),
+		},
+		Name:          mdl.Name,
+		LlmProviderId: mdl.ProviderID.String(),
+		RemoteName:    mdl.RemoteName,
+	}
+}
+
+func toProtoAuthMethod(method provider.AuthMethod) llmv1.AuthMethod {
+	switch method {
+	case provider.AuthMethodBearer:
+		return llmv1.AuthMethod_AUTH_METHOD_BEARER
+	default:
+		return llmv1.AuthMethod_AUTH_METHOD_UNSPECIFIED
+	}
+}
+
+func toStatusError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	if errors.Is(err, provider.ErrProviderNotFound) || errors.Is(err, model.ErrModelNotFound) {
+		return status.Error(codes.NotFound, err.Error())
+	}
+	if errors.Is(err, provider.ErrNoFieldsToUpdate) || errors.Is(err, model.ErrNoFieldsToUpdate) {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	if errors.Is(err, proxy.ErrInvalidBody) || errors.Is(err, proxy.ErrMissingModel) {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+	if errors.Is(err, proxy.ErrUnsupportedAuthMethod) || errors.Is(err, proxy.ErrMissingToken) {
+		return status.Error(codes.FailedPrecondition, err.Error())
+	}
+	return status.Error(codes.Internal, err.Error())
+}

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -31,6 +31,11 @@ type Provider struct {
 	UpdatedAt  time.Time
 }
 
+type ProviderWithToken struct {
+	Provider
+	Token string
+}
+
 type CreateInput struct {
 	Endpoint   string
 	AuthMethod AuthMethod
@@ -82,6 +87,20 @@ func (s *Store) Get(ctx context.Context, id uuid.UUID) (Provider, error) {
 			return Provider{}, ErrProviderNotFound
 		}
 		return Provider{}, fmt.Errorf("get provider: %w", err)
+	}
+	provider.AuthMethod = AuthMethod(authMethod)
+	return provider, nil
+}
+
+func (s *Store) GetWithToken(ctx context.Context, id uuid.UUID) (ProviderWithToken, error) {
+	row := s.pool.QueryRow(ctx, `SELECT id, endpoint, auth_method, token, created_at, updated_at FROM llm_providers WHERE id = $1`, id)
+	var provider ProviderWithToken
+	var authMethod string
+	if err := row.Scan(&provider.ID, &provider.Endpoint, &authMethod, &provider.Token, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ProviderWithToken{}, ErrProviderNotFound
+		}
+		return ProviderWithToken{}, fmt.Errorf("get provider: %w", err)
 	}
 	provider.AuthMethod = AuthMethod(authMethod)
 	return provider, nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,0 +1,390 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/agynio/llm/internal/model"
+	"github.com/agynio/llm/internal/provider"
+	"github.com/google/uuid"
+)
+
+var (
+	ErrInvalidBody           = errors.New("invalid body")
+	ErrMissingModel          = errors.New("model is required")
+	ErrUnsupportedAuthMethod = errors.New("unsupported auth method")
+	ErrMissingToken          = errors.New("provider token is required")
+)
+
+type ProviderStore interface {
+	GetWithToken(ctx context.Context, id uuid.UUID) (provider.ProviderWithToken, error)
+}
+
+type ModelStore interface {
+	Get(ctx context.Context, id uuid.UUID) (model.Model, error)
+}
+
+type Resolver struct {
+	providers ProviderStore
+	models    ModelStore
+}
+
+type ResolvedModel struct {
+	Model    model.Model
+	Provider provider.ProviderWithToken
+}
+
+func NewResolver(providers ProviderStore, models ModelStore) *Resolver {
+	return &Resolver{providers: providers, models: models}
+}
+
+func (r *Resolver) Resolve(ctx context.Context, modelID uuid.UUID) (ResolvedModel, error) {
+	mdl, err := r.models.Get(ctx, modelID)
+	if err != nil {
+		return ResolvedModel{}, err
+	}
+	prov, err := r.providers.GetWithToken(ctx, mdl.ProviderID)
+	if err != nil {
+		return ResolvedModel{}, err
+	}
+	return ResolvedModel{Model: mdl, Provider: prov}, nil
+}
+
+type Response struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+type StreamResponse struct {
+	StatusCode int
+	Header     http.Header
+	Body       io.ReadCloser
+}
+
+type Service struct {
+	resolver *Resolver
+	client   *http.Client
+}
+
+func NewService(resolver *Resolver, client *http.Client) *Service {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Service{resolver: resolver, client: client}
+}
+
+func (s *Service) CreateResponse(ctx context.Context, modelID uuid.UUID, body []byte) (Response, error) {
+	resolved, err := s.resolver.Resolve(ctx, modelID)
+	if err != nil {
+		return Response{}, err
+	}
+	updated, err := updateRequestBody(body, resolved.Model.RemoteName, false)
+	if err != nil {
+		return Response{}, err
+	}
+	return s.doRequest(ctx, resolved, updated, false)
+}
+
+func (s *Service) CreateResponseStream(ctx context.Context, modelID uuid.UUID, body []byte) (StreamResponse, error) {
+	resolved, err := s.resolver.Resolve(ctx, modelID)
+	if err != nil {
+		return StreamResponse{}, err
+	}
+	updated, err := updateRequestBody(body, resolved.Model.RemoteName, true)
+	if err != nil {
+		return StreamResponse{}, err
+	}
+	return s.doStreamRequest(ctx, resolved, updated)
+}
+
+func (s *Service) doRequest(ctx context.Context, resolved ResolvedModel, body []byte, stream bool) (Response, error) {
+	req, err := s.buildRequest(ctx, resolved, body, stream)
+	if err != nil {
+		return Response{}, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return Response{}, fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return Response{}, fmt.Errorf("read response: %w", err)
+	}
+
+	return Response{StatusCode: resp.StatusCode, Header: resp.Header.Clone(), Body: respBody}, nil
+}
+
+func (s *Service) doStreamRequest(ctx context.Context, resolved ResolvedModel, body []byte) (StreamResponse, error) {
+	req, err := s.buildRequest(ctx, resolved, body, true)
+	if err != nil {
+		return StreamResponse{}, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return StreamResponse{}, fmt.Errorf("send request: %w", err)
+	}
+	return StreamResponse{StatusCode: resp.StatusCode, Header: resp.Header.Clone(), Body: resp.Body}, nil
+}
+
+func (s *Service) buildRequest(ctx context.Context, resolved ResolvedModel, body []byte, stream bool) (*http.Request, error) {
+	endpoint := strings.TrimRight(resolved.Provider.Endpoint, "/")
+	if endpoint == "" {
+		return nil, fmt.Errorf("%w: provider endpoint is required", ErrInvalidBody)
+	}
+	url := endpoint + "/v1/responses"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if stream {
+		req.Header.Set("Accept", "text/event-stream")
+	}
+
+	method := resolved.Provider.AuthMethod
+	if method == "" {
+		method = provider.AuthMethodBearer
+	}
+	if method != provider.AuthMethodBearer {
+		return nil, ErrUnsupportedAuthMethod
+	}
+	token := strings.TrimSpace(resolved.Provider.Token)
+	if token == "" {
+		return nil, ErrMissingToken
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	return req, nil
+}
+
+type Event struct {
+	EventType string
+	Data      []byte
+}
+
+func ReadSSE(ctx context.Context, reader io.Reader, handle func(Event) error) error {
+	bufReader := bufio.NewReader(reader)
+	var (
+		eventType string
+		dataLines []string
+	)
+
+	emit := func() error {
+		if len(dataLines) == 0 && eventType == "" {
+			return nil
+		}
+		data := strings.Join(dataLines, "\n")
+		return handle(Event{EventType: eventType, Data: []byte(data)})
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		line, err := bufReader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("read sse: %w", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+
+		switch {
+		case line == "":
+			if err := emit(); err != nil {
+				return err
+			}
+			eventType = ""
+			dataLines = dataLines[:0]
+		case strings.HasPrefix(line, "event:"):
+			eventType = strings.TrimSpace(line[len("event:"):])
+		case strings.HasPrefix(line, "data:"):
+			data := strings.TrimLeft(line[len("data:"):], " ")
+			dataLines = append(dataLines, data)
+		default:
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+
+	if err := emit(); err != nil {
+		return err
+	}
+	return nil
+}
+
+type Handler struct {
+	service *Service
+}
+
+func NewHandler(service *Service) http.Handler {
+	return &Handler{service: service}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/v1/responses" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	_, modelID, stream, err := parseRequestBody(body)
+	if err != nil {
+		writeProxyError(w, err)
+		return
+	}
+
+	if stream {
+		resp, err := h.service.CreateResponseStream(r.Context(), modelID, body)
+		if err != nil {
+			writeProxyError(w, err)
+			return
+		}
+		defer resp.Body.Close()
+
+		copyHeaders(w.Header(), resp.Header, map[string]struct{}{"Content-Length": {}})
+		w.WriteHeader(resp.StatusCode)
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			_, _ = io.Copy(w, resp.Body)
+			return
+		}
+		if err := streamToClient(r.Context(), w, resp.Body); err != nil {
+			return
+		}
+		return
+	}
+
+	resp, err := h.service.CreateResponse(r.Context(), modelID, body)
+	if err != nil {
+		writeProxyError(w, err)
+		return
+	}
+	copyHeaders(w.Header(), resp.Header, nil)
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(resp.Body)
+}
+
+func parseRequestBody(body []byte) (map[string]any, uuid.UUID, bool, error) {
+	if len(body) == 0 {
+		return nil, uuid.UUID{}, false, fmt.Errorf("%w: body is empty", ErrInvalidBody)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, uuid.UUID{}, false, fmt.Errorf("%w: %v", ErrInvalidBody, err)
+	}
+
+	rawModel, ok := payload["model"]
+	if !ok {
+		return payload, uuid.UUID{}, false, ErrMissingModel
+	}
+	modelStr, ok := rawModel.(string)
+	if !ok || strings.TrimSpace(modelStr) == "" {
+		return payload, uuid.UUID{}, false, fmt.Errorf("%w: model must be a string", ErrInvalidBody)
+	}
+	modelID, err := uuid.Parse(modelStr)
+	if err != nil {
+		return payload, uuid.UUID{}, false, fmt.Errorf("%w: model must be a UUID", ErrInvalidBody)
+	}
+
+	stream := false
+	if rawStream, ok := payload["stream"]; ok {
+		value, ok := rawStream.(bool)
+		if !ok {
+			return payload, uuid.UUID{}, false, fmt.Errorf("%w: stream must be a boolean", ErrInvalidBody)
+		}
+		stream = value
+	}
+
+	return payload, modelID, stream, nil
+}
+
+func updateRequestBody(body []byte, remoteName string, forceStream bool) ([]byte, error) {
+	if len(body) == 0 {
+		return nil, fmt.Errorf("%w: body is empty", ErrInvalidBody)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidBody, err)
+	}
+	payload["model"] = remoteName
+	if forceStream {
+		payload["stream"] = true
+	}
+	updated, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidBody, err)
+	}
+	return updated, nil
+}
+
+func writeProxyError(w http.ResponseWriter, err error) {
+	status := http.StatusBadGateway
+	switch {
+	case errors.Is(err, ErrInvalidBody), errors.Is(err, ErrMissingModel):
+		status = http.StatusBadRequest
+	case errors.Is(err, provider.ErrProviderNotFound), errors.Is(err, model.ErrModelNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, ErrUnsupportedAuthMethod), errors.Is(err, ErrMissingToken):
+		status = http.StatusBadRequest
+	}
+	http.Error(w, err.Error(), status)
+}
+
+func copyHeaders(dst, src http.Header, skip map[string]struct{}) {
+	for key, values := range src {
+		canonical := http.CanonicalHeaderKey(key)
+		if skip != nil {
+			if _, ok := skip[canonical]; ok {
+				continue
+			}
+		}
+		for _, value := range values {
+			dst.Add(canonical, value)
+		}
+	}
+}
+
+func streamToClient(ctx context.Context, w http.ResponseWriter, body io.Reader) error {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		return errors.New("streaming unsupported")
+	}
+	buffer := make([]byte, 32*1024)
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		n, err := body.Read(buffer)
+		if n > 0 {
+			if _, writeErr := w.Write(buffer[:n]); writeErr != nil {
+				return writeErr
+			}
+			flusher.Flush()
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- implement LLMService gRPC server with provider/model CRUD and proxy RPCs
- add proxy service + HTTP handler for /v1/responses streaming and non-streaming
- wire main entrypoint with config, migrations, stores, gRPC/HTTP servers, and graceful shutdown

## Testing
- go mod tidy
- go vet ./...
- go build ./...
- go test ./...

## Issue
Refs #1