### PR TITLE
fix(chart): preserve service-base spacing

### DIFF
--- a/charts/llm/Chart.yaml
+++ b/charts/llm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: llm
 description: Helm chart for deploying the agyn LLM service.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.2.0
+appVersion: 0.2.0
 home: https://github.com/agynio/llm
 sources:
   - https://github.com/agynio/llm

--- a/charts/llm/templates/service-base.yaml
+++ b/charts/llm/templates/service-base.yaml
@@ -1,9 +1,9 @@
 {{- include "llm.configureEnv" . -}}
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}
+{{ include "service-base.rbac" . }}
+{{ include "service-base.serviceAccount" . }}
+{{ include "service-base.service" . }}
+{{ include "service-base.deployment" . }}
+{{ include "service-base.hpa" . }}
+{{ include "service-base.ingress" . }}
+{{ include "service-base.pdb" . }}
+{{ include "service-base.metrics" . }}


### PR DESCRIPTION
## Summary
- preserve whitespace between service-base template includes to avoid YAML concatenation
- bump chart version/appVersion to 0.2.0

## Testing
- helm dependency build charts/llm
- helm lint charts/llm --set llm.databaseUrl.value=dummy
- helm template test charts/llm --set llm.databaseUrl.value=dummy
- go vet ./...
- go test ./...
- go test ./... -json
- go build ./...

Refs #25