### PR TITLE
Add protocol support to LLM providers

### DIFF
--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -61,11 +61,16 @@ func (s *Server) CreateLLMProvider(ctx context.Context, req *llmv1.CreateLLMProv
 	if err != nil {
 		return nil, err
 	}
+	protocol, err := parseProtocol(req.GetProtocol(), true)
+	if err != nil {
+		return nil, err
+	}
 
 	created, err := s.providers.Create(ctx, provider.CreateInput{
 		OrganizationID: organizationID,
 		Endpoint:       endpoint,
 		AuthMethod:     authMethod,
+		Protocol:       protocol,
 		Token:          token,
 	})
 	if err != nil {
@@ -115,6 +120,13 @@ func (s *Server) UpdateLLMProvider(ctx context.Context, req *llmv1.UpdateLLMProv
 			return nil, err
 		}
 		input.AuthMethod = &method
+	}
+	if req.Protocol != nil {
+		protocol, err := parseProtocol(req.GetProtocol(), false)
+		if err != nil {
+			return nil, err
+		}
+		input.Protocol = &protocol
 	}
 	if req.Token != nil {
 		token := strings.TrimSpace(req.GetToken())
@@ -361,6 +373,8 @@ func (s *Server) ResolveModel(ctx context.Context, req *llmv1.ResolveModelReques
 		Token:          prov.Token,
 		RemoteName:     mdl.RemoteName,
 		OrganizationId: prov.OrganizationID.String(),
+		Protocol:       toProtoProtocol(prov.Protocol),
+		AuthMethod:     toProtoAuthMethod(prov.AuthMethod),
 	}, nil
 }
 
@@ -380,6 +394,8 @@ func parseAuthMethod(value llmv1.AuthMethod, allowUnspecified bool) (provider.Au
 	switch value {
 	case llmv1.AuthMethod_AUTH_METHOD_BEARER:
 		return provider.AuthMethodBearer, nil
+	case llmv1.AuthMethod_AUTH_METHOD_X_API_KEY:
+		return provider.AuthMethodXAPIKey, nil
 	case llmv1.AuthMethod_AUTH_METHOD_UNSPECIFIED:
 		if allowUnspecified {
 			return provider.AuthMethodBearer, nil
@@ -387,6 +403,22 @@ func parseAuthMethod(value llmv1.AuthMethod, allowUnspecified bool) (provider.Au
 		return "", status.Error(codes.InvalidArgument, "auth_method must be set")
 	default:
 		return "", status.Error(codes.InvalidArgument, "auth_method is invalid")
+	}
+}
+
+func parseProtocol(value llmv1.Protocol, allowUnspecified bool) (provider.Protocol, error) {
+	switch value {
+	case llmv1.Protocol_PROTOCOL_RESPONSES:
+		return provider.ProtocolResponses, nil
+	case llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES:
+		return provider.ProtocolAnthropicMessages, nil
+	case llmv1.Protocol_PROTOCOL_UNSPECIFIED:
+		if allowUnspecified {
+			return provider.ProtocolResponses, nil
+		}
+		return "", status.Error(codes.InvalidArgument, "protocol must be set")
+	default:
+		return "", status.Error(codes.InvalidArgument, "protocol is invalid")
 	}
 }
 
@@ -400,6 +432,7 @@ func toProtoProvider(prov provider.Provider) *llmv1.LLMProvider {
 		Endpoint:       prov.Endpoint,
 		AuthMethod:     toProtoAuthMethod(prov.AuthMethod),
 		OrganizationId: prov.OrganizationID.String(),
+		Protocol:       toProtoProtocol(prov.Protocol),
 	}
 }
 
@@ -420,8 +453,21 @@ func toProtoAuthMethod(method provider.AuthMethod) llmv1.AuthMethod {
 	switch method {
 	case provider.AuthMethodBearer:
 		return llmv1.AuthMethod_AUTH_METHOD_BEARER
+	case provider.AuthMethodXAPIKey:
+		return llmv1.AuthMethod_AUTH_METHOD_X_API_KEY
 	default:
 		panic(fmt.Sprintf("unexpected auth method: %q", method))
+	}
+}
+
+func toProtoProtocol(protocol provider.Protocol) llmv1.Protocol {
+	switch protocol {
+	case provider.ProtocolResponses:
+		return llmv1.Protocol_PROTOCOL_RESPONSES
+	case provider.ProtocolAnthropicMessages:
+		return llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES
+	default:
+		panic(fmt.Sprintf("unexpected protocol: %q", protocol))
 	}
 }
 

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -82,21 +82,13 @@ func (f *fakeProviderStore) Get(ctx context.Context, id uuid.UUID) (provider.Pro
 
 func (f *fakeProviderStore) GetWithToken(ctx context.Context, id uuid.UUID) (provider.ProviderWithToken, error) {
 	f.getWithTokenID = id
-	authMethod := f.getWithTokenAuth
-	if authMethod == "" {
-		authMethod = provider.AuthMethodBearer
-	}
-	protocol := f.getWithTokenProtocol
-	if protocol == "" {
-		protocol = provider.ProtocolResponses
-	}
 	return provider.ProviderWithToken{
 		Provider: provider.Provider{
 			ID:             id,
 			OrganizationID: f.getWithTokenOrgID,
 			Endpoint:       "https://example.com",
-			AuthMethod:     authMethod,
-			Protocol:       protocol,
+			AuthMethod:     f.getWithTokenAuth,
+			Protocol:       f.getWithTokenProtocol,
 			CreatedAt:      time.Unix(0, 0),
 			UpdatedAt:      time.Unix(0, 0),
 		},
@@ -198,6 +190,26 @@ func TestCreateLLMProviderUsesOrganizationID(t *testing.T) {
 	}
 	if providers.createAuthMethod != provider.AuthMethodBearer {
 		t.Fatalf("expected auth method %s, got %s", provider.AuthMethodBearer, providers.createAuthMethod)
+	}
+	if providers.createProtocol != provider.ProtocolResponses {
+		t.Fatalf("expected protocol %s, got %s", provider.ProtocolResponses, providers.createProtocol)
+	}
+}
+
+func TestCreateLLMProviderDefaultsProtocol(t *testing.T) {
+	organizationID := uuid.MustParse("6a8262f5-64f3-4c19-8215-8c0275733b39")
+	providers := &fakeProviderStore{}
+	server := New(providers, &fakeModelStore{})
+
+	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
+		Endpoint:       "https://example.com",
+		Token:          "token",
+		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
+		Protocol:       llmv1.Protocol_PROTOCOL_UNSPECIFIED,
+		OrganizationId: organizationID.String(),
+	})
+	if err != nil {
+		t.Fatalf("CreateLLMProvider: %v", err)
 	}
 	if providers.createProtocol != provider.ProtocolResponses {
 		t.Fatalf("expected protocol %s, got %s", provider.ProtocolResponses, providers.createProtocol)
@@ -416,5 +428,71 @@ func TestResolveModelReturnsProviderDetails(t *testing.T) {
 	}
 	if resp.Protocol != llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES {
 		t.Fatalf("expected protocol %v, got %v", llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES, resp.Protocol)
+	}
+}
+
+func TestParseAuthMethodXAPIKey(t *testing.T) {
+	method, err := parseAuthMethod(llmv1.AuthMethod_AUTH_METHOD_X_API_KEY, false)
+	if err != nil {
+		t.Fatalf("parseAuthMethod: %v", err)
+	}
+	if method != provider.AuthMethodXAPIKey {
+		t.Fatalf("expected auth method %s, got %s", provider.AuthMethodXAPIKey, method)
+	}
+}
+
+func TestParseProtocol(t *testing.T) {
+	cases := []struct {
+		name             string
+		value            llmv1.Protocol
+		allowUnspecified bool
+		want             provider.Protocol
+		wantCode         codes.Code
+	}{
+		{
+			name:             "responses",
+			value:            llmv1.Protocol_PROTOCOL_RESPONSES,
+			allowUnspecified: false,
+			want:             provider.ProtocolResponses,
+		},
+		{
+			name:             "anthropic messages",
+			value:            llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES,
+			allowUnspecified: false,
+			want:             provider.ProtocolAnthropicMessages,
+		},
+		{
+			name:             "unspecified allowed",
+			value:            llmv1.Protocol_PROTOCOL_UNSPECIFIED,
+			allowUnspecified: true,
+			want:             provider.ProtocolResponses,
+		},
+		{
+			name:             "unspecified rejected",
+			value:            llmv1.Protocol_PROTOCOL_UNSPECIFIED,
+			allowUnspecified: false,
+			wantCode:         codes.InvalidArgument,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			protocol, err := parseProtocol(tc.value, tc.allowUnspecified)
+			if tc.wantCode != codes.OK {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				if status.Code(err) != tc.wantCode {
+					t.Fatalf("expected code %v, got %v", tc.wantCode, status.Code(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseProtocol: %v", err)
+			}
+			if protocol != tc.want {
+				t.Fatalf("expected protocol %s, got %s", tc.want, protocol)
+			}
+		})
 	}
 }

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -44,21 +44,32 @@ func TestToStatusErrorMappings(t *testing.T) {
 
 type fakeProviderStore struct {
 	createOrganizationID uuid.UUID
+	createAuthMethod     provider.AuthMethod
+	createProtocol       provider.Protocol
 	listOrganizationID   uuid.UUID
 	getID                uuid.UUID
 	getWithTokenID       uuid.UUID
 	getWithTokenOrgID    uuid.UUID
+	getWithTokenAuth     provider.AuthMethod
+	getWithTokenProtocol provider.Protocol
 	updateID             uuid.UUID
+	updateAuthMethod     provider.AuthMethod
+	updateProtocol       provider.Protocol
+	updateAuthMethodSet  bool
+	updateProtocolSet    bool
 	deleteID             uuid.UUID
 }
 
 func (f *fakeProviderStore) Create(ctx context.Context, input provider.CreateInput) (provider.Provider, error) {
 	f.createOrganizationID = input.OrganizationID
+	f.createAuthMethod = input.AuthMethod
+	f.createProtocol = input.Protocol
 	return provider.Provider{
 		ID:             uuid.MustParse("b0d2c70c-f2e7-4b33-94a1-d52468ed7ff1"),
 		OrganizationID: input.OrganizationID,
 		Endpoint:       input.Endpoint,
 		AuthMethod:     input.AuthMethod,
+		Protocol:       input.Protocol,
 		CreatedAt:      time.Unix(0, 0),
 		UpdatedAt:      time.Unix(0, 0),
 	}, nil
@@ -66,17 +77,26 @@ func (f *fakeProviderStore) Create(ctx context.Context, input provider.CreateInp
 
 func (f *fakeProviderStore) Get(ctx context.Context, id uuid.UUID) (provider.Provider, error) {
 	f.getID = id
-	return provider.Provider{ID: id, OrganizationID: uuid.Nil, Endpoint: "https://example.com", AuthMethod: provider.AuthMethodBearer, CreatedAt: time.Unix(0, 0), UpdatedAt: time.Unix(0, 0)}, nil
+	return provider.Provider{ID: id, OrganizationID: uuid.Nil, Endpoint: "https://example.com", AuthMethod: provider.AuthMethodBearer, Protocol: provider.ProtocolResponses, CreatedAt: time.Unix(0, 0), UpdatedAt: time.Unix(0, 0)}, nil
 }
 
 func (f *fakeProviderStore) GetWithToken(ctx context.Context, id uuid.UUID) (provider.ProviderWithToken, error) {
 	f.getWithTokenID = id
+	authMethod := f.getWithTokenAuth
+	if authMethod == "" {
+		authMethod = provider.AuthMethodBearer
+	}
+	protocol := f.getWithTokenProtocol
+	if protocol == "" {
+		protocol = provider.ProtocolResponses
+	}
 	return provider.ProviderWithToken{
 		Provider: provider.Provider{
 			ID:             id,
 			OrganizationID: f.getWithTokenOrgID,
 			Endpoint:       "https://example.com",
-			AuthMethod:     provider.AuthMethodBearer,
+			AuthMethod:     authMethod,
+			Protocol:       protocol,
 			CreatedAt:      time.Unix(0, 0),
 			UpdatedAt:      time.Unix(0, 0),
 		},
@@ -86,7 +106,19 @@ func (f *fakeProviderStore) GetWithToken(ctx context.Context, id uuid.UUID) (pro
 
 func (f *fakeProviderStore) Update(ctx context.Context, input provider.UpdateInput) (provider.Provider, error) {
 	f.updateID = input.ID
-	return provider.Provider{ID: input.ID, OrganizationID: uuid.Nil, Endpoint: "https://example.com", AuthMethod: provider.AuthMethodBearer, CreatedAt: time.Unix(0, 0), UpdatedAt: time.Unix(0, 0)}, nil
+	authMethod := provider.AuthMethodBearer
+	protocol := provider.ProtocolResponses
+	if input.AuthMethod != nil {
+		f.updateAuthMethod = *input.AuthMethod
+		f.updateAuthMethodSet = true
+		authMethod = *input.AuthMethod
+	}
+	if input.Protocol != nil {
+		f.updateProtocol = *input.Protocol
+		f.updateProtocolSet = true
+		protocol = *input.Protocol
+	}
+	return provider.Provider{ID: input.ID, OrganizationID: uuid.Nil, Endpoint: "https://example.com", AuthMethod: authMethod, Protocol: protocol, CreatedAt: time.Unix(0, 0), UpdatedAt: time.Unix(0, 0)}, nil
 }
 
 func (f *fakeProviderStore) Delete(ctx context.Context, id uuid.UUID) error {
@@ -164,6 +196,36 @@ func TestCreateLLMProviderUsesOrganizationID(t *testing.T) {
 	if providers.createOrganizationID != organizationID {
 		t.Fatalf("expected organization %s, got %s", organizationID, providers.createOrganizationID)
 	}
+	if providers.createAuthMethod != provider.AuthMethodBearer {
+		t.Fatalf("expected auth method %s, got %s", provider.AuthMethodBearer, providers.createAuthMethod)
+	}
+	if providers.createProtocol != provider.ProtocolResponses {
+		t.Fatalf("expected protocol %s, got %s", provider.ProtocolResponses, providers.createProtocol)
+	}
+}
+
+func TestCreateLLMProviderSupportsXAPIKey(t *testing.T) {
+	organizationID := uuid.MustParse("83eb6de8-289b-4b25-8752-23d73bb2e346")
+	providers := &fakeProviderStore{}
+	server := New(providers, &fakeModelStore{})
+	protocol := llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES
+
+	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
+		Endpoint:       "https://example.com",
+		Token:          "token",
+		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
+		Protocol:       protocol,
+		OrganizationId: organizationID.String(),
+	})
+	if err != nil {
+		t.Fatalf("CreateLLMProvider: %v", err)
+	}
+	if providers.createAuthMethod != provider.AuthMethodXAPIKey {
+		t.Fatalf("expected auth method %s, got %s", provider.AuthMethodXAPIKey, providers.createAuthMethod)
+	}
+	if providers.createProtocol != provider.ProtocolAnthropicMessages {
+		t.Fatalf("expected protocol %s, got %s", provider.ProtocolAnthropicMessages, providers.createProtocol)
+	}
 }
 
 func TestGetLLMProviderUsesID(t *testing.T) {
@@ -185,16 +247,26 @@ func TestUpdateLLMProviderUsesID(t *testing.T) {
 	providers := &fakeProviderStore{}
 	server := New(providers, &fakeModelStore{})
 	endpoint := "https://update.example.com"
+	protocol := llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES
+	authMethod := llmv1.AuthMethod_AUTH_METHOD_X_API_KEY
 
 	_, err := server.UpdateLLMProvider(contextWithIdentity(), &llmv1.UpdateLLMProviderRequest{
-		Id:       providerID.String(),
-		Endpoint: &endpoint,
+		Id:         providerID.String(),
+		Endpoint:   &endpoint,
+		Protocol:   &protocol,
+		AuthMethod: &authMethod,
 	})
 	if err != nil {
 		t.Fatalf("UpdateLLMProvider: %v", err)
 	}
 	if providers.updateID != providerID {
 		t.Fatalf("expected provider id %s, got %s", providerID, providers.updateID)
+	}
+	if !providers.updateAuthMethodSet || providers.updateAuthMethod != provider.AuthMethodXAPIKey {
+		t.Fatalf("expected auth method %s, got %s", provider.AuthMethodXAPIKey, providers.updateAuthMethod)
+	}
+	if !providers.updateProtocolSet || providers.updateProtocol != provider.ProtocolAnthropicMessages {
+		t.Fatalf("expected protocol %s, got %s", provider.ProtocolAnthropicMessages, providers.updateProtocol)
 	}
 }
 
@@ -309,7 +381,11 @@ func TestResolveModelReturnsProviderDetails(t *testing.T) {
 	modelID := uuid.MustParse("6e1a1a68-1e0f-4b07-8362-0a22e4c6bb86")
 	providerID := uuid.MustParse("3a6f3fb1-6372-4c30-bf34-0ff24511d9c0")
 	organizationID := uuid.MustParse("d65d0b42-33a1-45ac-a025-78f9117c3468")
-	providers := &fakeProviderStore{getWithTokenOrgID: organizationID}
+	providers := &fakeProviderStore{
+		getWithTokenOrgID:    organizationID,
+		getWithTokenAuth:     provider.AuthMethodXAPIKey,
+		getWithTokenProtocol: provider.ProtocolAnthropicMessages,
+	}
 	models := &fakeModelStore{getModel: model.Model{ProviderID: providerID, RemoteName: "remote", OrganizationID: organizationID, Name: "model"}}
 	server := New(providers, models)
 
@@ -334,5 +410,11 @@ func TestResolveModelReturnsProviderDetails(t *testing.T) {
 	}
 	if resp.OrganizationId != organizationID.String() {
 		t.Fatalf("expected organization %s, got %s", organizationID, resp.OrganizationId)
+	}
+	if resp.AuthMethod != llmv1.AuthMethod_AUTH_METHOD_X_API_KEY {
+		t.Fatalf("expected auth method %v, got %v", llmv1.AuthMethod_AUTH_METHOD_X_API_KEY, resp.AuthMethod)
+	}
+	if resp.Protocol != llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES {
+		t.Fatalf("expected protocol %v, got %v", llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES, resp.Protocol)
 	}
 }

--- a/internal/provider/store.go
+++ b/internal/provider/store.go
@@ -16,7 +16,15 @@ import (
 type AuthMethod string
 
 const (
-	AuthMethodBearer AuthMethod = "bearer"
+	AuthMethodBearer  AuthMethod = "bearer"
+	AuthMethodXAPIKey AuthMethod = "x-api-key"
+)
+
+type Protocol string
+
+const (
+	ProtocolResponses         Protocol = "responses"
+	ProtocolAnthropicMessages Protocol = "anthropic-messages"
 )
 
 var (
@@ -30,6 +38,7 @@ type Provider struct {
 	OrganizationID uuid.UUID
 	Endpoint       string
 	AuthMethod     AuthMethod
+	Protocol       Protocol
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }
@@ -43,6 +52,7 @@ type CreateInput struct {
 	OrganizationID uuid.UUID
 	Endpoint       string
 	AuthMethod     AuthMethod
+	Protocol       Protocol
 	Token          string
 }
 
@@ -50,6 +60,7 @@ type UpdateInput struct {
 	ID         uuid.UUID
 	Endpoint   *string
 	AuthMethod *AuthMethod
+	Protocol   *Protocol
 	Token      *string
 }
 
@@ -67,46 +78,52 @@ func NewStore(pool *pgxpool.Pool) *Store {
 }
 
 func (s *Store) Create(ctx context.Context, input CreateInput) (Provider, error) {
-	row := s.pool.QueryRow(ctx, `INSERT INTO llm_providers (organization_id, endpoint, auth_method, token) VALUES ($1, $2, $3, $4) RETURNING id, organization_id, endpoint, auth_method, created_at, updated_at`, input.OrganizationID, input.Endpoint, string(input.AuthMethod), input.Token)
+	row := s.pool.QueryRow(ctx, `INSERT INTO llm_providers (organization_id, endpoint, auth_method, protocol, token) VALUES ($1, $2, $3, $4, $5) RETURNING id, organization_id, endpoint, auth_method, protocol, created_at, updated_at`, input.OrganizationID, input.Endpoint, string(input.AuthMethod), string(input.Protocol), input.Token)
 	var provider Provider
 	var authMethod string
-	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
+	var protocol string
+	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &protocol, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
 		return Provider{}, fmt.Errorf("insert provider: %w", err)
 	}
 	provider.AuthMethod = AuthMethod(authMethod)
+	provider.Protocol = Protocol(protocol)
 	return provider, nil
 }
 
 func (s *Store) Get(ctx context.Context, id uuid.UUID) (Provider, error) {
-	row := s.pool.QueryRow(ctx, `SELECT id, organization_id, endpoint, auth_method, created_at, updated_at FROM llm_providers WHERE id = $1`, id)
+	row := s.pool.QueryRow(ctx, `SELECT id, organization_id, endpoint, auth_method, protocol, created_at, updated_at FROM llm_providers WHERE id = $1`, id)
 	var provider Provider
 	var authMethod string
-	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
+	var protocol string
+	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &protocol, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Provider{}, ErrProviderNotFound
 		}
 		return Provider{}, fmt.Errorf("get provider: %w", err)
 	}
 	provider.AuthMethod = AuthMethod(authMethod)
+	provider.Protocol = Protocol(protocol)
 	return provider, nil
 }
 
 func (s *Store) GetWithToken(ctx context.Context, id uuid.UUID) (ProviderWithToken, error) {
-	row := s.pool.QueryRow(ctx, `SELECT id, organization_id, endpoint, auth_method, token, created_at, updated_at FROM llm_providers WHERE id = $1`, id)
+	row := s.pool.QueryRow(ctx, `SELECT id, organization_id, endpoint, auth_method, protocol, token, created_at, updated_at FROM llm_providers WHERE id = $1`, id)
 	var provider ProviderWithToken
 	var authMethod string
-	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &provider.Token, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
+	var protocol string
+	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &protocol, &provider.Token, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ProviderWithToken{}, ErrProviderNotFound
 		}
 		return ProviderWithToken{}, fmt.Errorf("get provider: %w", err)
 	}
 	provider.AuthMethod = AuthMethod(authMethod)
+	provider.Protocol = Protocol(protocol)
 	return provider, nil
 }
 func (s *Store) Update(ctx context.Context, input UpdateInput) (Provider, error) {
-	setClauses := make([]string, 0, 3)
-	args := make([]any, 0, 4)
+	setClauses := make([]string, 0, 4)
+	args := make([]any, 0, 5)
 
 	if input.Endpoint != nil {
 		setClauses = append(setClauses, fmt.Sprintf("endpoint = $%d", len(args)+1))
@@ -115,6 +132,10 @@ func (s *Store) Update(ctx context.Context, input UpdateInput) (Provider, error)
 	if input.AuthMethod != nil {
 		setClauses = append(setClauses, fmt.Sprintf("auth_method = $%d", len(args)+1))
 		args = append(args, string(*input.AuthMethod))
+	}
+	if input.Protocol != nil {
+		setClauses = append(setClauses, fmt.Sprintf("protocol = $%d", len(args)+1))
+		args = append(args, string(*input.Protocol))
 	}
 	if input.Token != nil {
 		setClauses = append(setClauses, fmt.Sprintf("token = $%d", len(args)+1))
@@ -126,18 +147,20 @@ func (s *Store) Update(ctx context.Context, input UpdateInput) (Provider, error)
 	setClauses = append(setClauses, "updated_at = NOW()")
 	args = append(args, input.ID)
 
-	query := fmt.Sprintf("UPDATE llm_providers SET %s WHERE id = $%d RETURNING id, organization_id, endpoint, auth_method, created_at, updated_at", strings.Join(setClauses, ", "), len(args))
+	query := fmt.Sprintf("UPDATE llm_providers SET %s WHERE id = $%d RETURNING id, organization_id, endpoint, auth_method, protocol, created_at, updated_at", strings.Join(setClauses, ", "), len(args))
 	row := s.pool.QueryRow(ctx, query, args...)
 
 	var provider Provider
 	var authMethod string
-	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
+	var protocol string
+	if err := row.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &protocol, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Provider{}, ErrProviderNotFound
 		}
 		return Provider{}, fmt.Errorf("update provider: %w", err)
 	}
 	provider.AuthMethod = AuthMethod(authMethod)
+	provider.Protocol = Protocol(protocol)
 	return provider, nil
 }
 
@@ -160,7 +183,7 @@ func (s *Store) List(ctx context.Context, organizationID uuid.UUID, pageSize int
 	limit := normalizePageSize(pageSize)
 
 	query := strings.Builder{}
-	query.WriteString(`SELECT id, organization_id, endpoint, auth_method, created_at, updated_at FROM llm_providers WHERE organization_id = $1`)
+	query.WriteString(`SELECT id, organization_id, endpoint, auth_method, protocol, created_at, updated_at FROM llm_providers WHERE organization_id = $1`)
 	args := []any{organizationID}
 	paramIndex := 2
 	if cursor != nil {
@@ -186,7 +209,8 @@ func (s *Store) List(ctx context.Context, organizationID uuid.UUID, pageSize int
 	for rows.Next() {
 		var provider Provider
 		var authMethod string
-		if err := rows.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
+		var protocol string
+		if err := rows.Scan(&provider.ID, &provider.OrganizationID, &provider.Endpoint, &authMethod, &protocol, &provider.CreatedAt, &provider.UpdatedAt); err != nil {
 			return ListResult{}, fmt.Errorf("scan provider: %w", err)
 		}
 		if int32(len(providers)) == limit {
@@ -194,6 +218,7 @@ func (s *Store) List(ctx context.Context, organizationID uuid.UUID, pageSize int
 			break
 		}
 		provider.AuthMethod = AuthMethod(authMethod)
+		provider.Protocol = Protocol(protocol)
 		providers = append(providers, provider)
 		last = provider
 	}

--- a/migrations/0003_add_protocol.sql
+++ b/migrations/0003_add_protocol.sql
@@ -1,0 +1,1 @@
+ALTER TABLE llm_providers ADD COLUMN protocol TEXT NOT NULL DEFAULT 'responses';


### PR DESCRIPTION
## Summary
- add protocol migration and provider store mappings
- handle protocol and x-api-key auth in gRPC service
- expand gRPC server tests for new fields

## Testing
- go vet ./...
- go test ./...

Refs #39