### PR TITLE
feat(llm): implement TestModel

### DIFF
--- a/cmd/llm/main.go
+++ b/cmd/llm/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -62,7 +63,7 @@ func run() error {
 	healthpb.RegisterHealthServer(grpcServer, healthServer)
 	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	healthServer.SetServingStatus("agynio.api.llm.v1.LLMService", healthpb.HealthCheckResponse_SERVING)
-	llmv1.RegisterLLMServiceServer(grpcServer, grpcserver.New(providerStore, modelStore))
+	llmv1.RegisterLLMServiceServer(grpcServer, grpcserver.New(providerStore, modelStore, http.DefaultClient))
 
 	grpcListener, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -37,10 +37,14 @@ type Server struct {
 	llmv1.UnimplementedLLMServiceServer
 	providers ProviderStore
 	models    ModelStore
+	httpClient HTTPClient
 }
 
-func New(providers ProviderStore, models ModelStore) *Server {
-	return &Server{providers: providers, models: models}
+func New(providers ProviderStore, models ModelStore, httpClient HTTPClient) *Server {
+	if httpClient == nil {
+		panic("http client is required")
+	}
+	return &Server{providers: providers, models: models, httpClient: httpClient}
 }
 
 func (s *Server) CreateLLMProvider(ctx context.Context, req *llmv1.CreateLLMProviderRequest) (*llmv1.CreateLLMProviderResponse, error) {

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -3,6 +3,7 @@ package grpcserver
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -171,10 +172,14 @@ func contextWithIdentity() context.Context {
 	))
 }
 
+func newTestServer(providers ProviderStore, models ModelStore) *Server {
+	return New(providers, models, http.DefaultClient)
+}
+
 func TestCreateLLMProviderUsesOrganizationID(t *testing.T) {
 	organizationID := uuid.MustParse("f79b0bde-9e46-44c0-9756-9eac9f383acd")
 	providers := &fakeProviderStore{}
-	server := New(providers, &fakeModelStore{})
+	server := newTestServer(providers, &fakeModelStore{})
 
 	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
 		Endpoint:       "https://example.com",
@@ -199,7 +204,7 @@ func TestCreateLLMProviderUsesOrganizationID(t *testing.T) {
 func TestCreateLLMProviderDefaultsProtocol(t *testing.T) {
 	organizationID := uuid.MustParse("6a8262f5-64f3-4c19-8215-8c0275733b39")
 	providers := &fakeProviderStore{}
-	server := New(providers, &fakeModelStore{})
+	server := newTestServer(providers, &fakeModelStore{})
 
 	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
 		Endpoint:       "https://example.com",
@@ -219,7 +224,7 @@ func TestCreateLLMProviderDefaultsProtocol(t *testing.T) {
 func TestCreateLLMProviderSupportsXAPIKey(t *testing.T) {
 	organizationID := uuid.MustParse("83eb6de8-289b-4b25-8752-23d73bb2e346")
 	providers := &fakeProviderStore{}
-	server := New(providers, &fakeModelStore{})
+	server := newTestServer(providers, &fakeModelStore{})
 	protocol := llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES
 
 	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
@@ -243,7 +248,7 @@ func TestCreateLLMProviderSupportsXAPIKey(t *testing.T) {
 func TestGetLLMProviderUsesID(t *testing.T) {
 	providerID := uuid.MustParse("b2910fd9-9f3b-4f31-9c3b-369b3a2040e0")
 	providers := &fakeProviderStore{}
-	server := New(providers, &fakeModelStore{})
+	server := newTestServer(providers, &fakeModelStore{})
 
 	_, err := server.GetLLMProvider(contextWithIdentity(), &llmv1.GetLLMProviderRequest{Id: providerID.String()})
 	if err != nil {
@@ -257,7 +262,7 @@ func TestGetLLMProviderUsesID(t *testing.T) {
 func TestUpdateLLMProviderUsesID(t *testing.T) {
 	providerID := uuid.MustParse("56a4b7e4-3954-4f85-9df2-b0b2371c91f8")
 	providers := &fakeProviderStore{}
-	server := New(providers, &fakeModelStore{})
+	server := newTestServer(providers, &fakeModelStore{})
 	endpoint := "https://update.example.com"
 	protocol := llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES
 	authMethod := llmv1.AuthMethod_AUTH_METHOD_X_API_KEY
@@ -285,7 +290,7 @@ func TestUpdateLLMProviderUsesID(t *testing.T) {
 func TestDeleteLLMProviderUsesID(t *testing.T) {
 	providerID := uuid.MustParse("0ea4b5b9-7fe0-4e1f-b1a1-a4b9f71001d5")
 	providers := &fakeProviderStore{}
-	server := New(providers, &fakeModelStore{})
+	server := newTestServer(providers, &fakeModelStore{})
 
 	_, err := server.DeleteLLMProvider(contextWithIdentity(), &llmv1.DeleteLLMProviderRequest{Id: providerID.String()})
 	if err != nil {
@@ -299,7 +304,7 @@ func TestDeleteLLMProviderUsesID(t *testing.T) {
 func TestListLLMProvidersUsesOrganizationID(t *testing.T) {
 	organizationID := uuid.MustParse("22cb0675-4c69-4aa6-a41f-44cde1d2b0f4")
 	providers := &fakeProviderStore{}
-	server := New(providers, &fakeModelStore{})
+	server := newTestServer(providers, &fakeModelStore{})
 
 	_, err := server.ListLLMProviders(context.Background(), &llmv1.ListLLMProvidersRequest{PageSize: 5, OrganizationId: organizationID.String()})
 	if err != nil {
@@ -313,7 +318,7 @@ func TestListLLMProvidersUsesOrganizationID(t *testing.T) {
 func TestCreateModelUsesOrganizationID(t *testing.T) {
 	organizationID := uuid.MustParse("6d68256e-4f2a-4d20-9f2b-8e93b5c09a4b")
 	models := &fakeModelStore{}
-	server := New(&fakeProviderStore{}, models)
+	server := newTestServer(&fakeProviderStore{}, models)
 
 	_, err := server.CreateModel(context.Background(), &llmv1.CreateModelRequest{
 		Name:           "name",
@@ -332,7 +337,7 @@ func TestCreateModelUsesOrganizationID(t *testing.T) {
 func TestGetModelUsesID(t *testing.T) {
 	modelID := uuid.MustParse("64b7b95d-1d57-4a95-8a13-2fdc7d4e5408")
 	models := &fakeModelStore{}
-	server := New(&fakeProviderStore{}, models)
+	server := newTestServer(&fakeProviderStore{}, models)
 
 	_, err := server.GetModel(contextWithIdentity(), &llmv1.GetModelRequest{Id: modelID.String()})
 	if err != nil {
@@ -346,7 +351,7 @@ func TestGetModelUsesID(t *testing.T) {
 func TestUpdateModelUsesID(t *testing.T) {
 	modelID := uuid.MustParse("534d5726-ecb8-4d47-967b-8a337df56c52")
 	models := &fakeModelStore{}
-	server := New(&fakeProviderStore{}, models)
+	server := newTestServer(&fakeProviderStore{}, models)
 	name := "updated"
 
 	_, err := server.UpdateModel(contextWithIdentity(), &llmv1.UpdateModelRequest{
@@ -364,7 +369,7 @@ func TestUpdateModelUsesID(t *testing.T) {
 func TestDeleteModelUsesID(t *testing.T) {
 	modelID := uuid.MustParse("da8c9c3a-8791-4d9f-a73f-83f31138dc28")
 	models := &fakeModelStore{}
-	server := New(&fakeProviderStore{}, models)
+	server := newTestServer(&fakeProviderStore{}, models)
 
 	_, err := server.DeleteModel(contextWithIdentity(), &llmv1.DeleteModelRequest{Id: modelID.String()})
 	if err != nil {
@@ -378,7 +383,7 @@ func TestDeleteModelUsesID(t *testing.T) {
 func TestListModelsUsesOrganizationID(t *testing.T) {
 	organizationID := uuid.MustParse("0f42fd48-4d3e-4382-b787-6e681d8b82a0")
 	models := &fakeModelStore{}
-	server := New(&fakeProviderStore{}, models)
+	server := newTestServer(&fakeProviderStore{}, models)
 
 	_, err := server.ListModels(context.Background(), &llmv1.ListModelsRequest{PageSize: 5, OrganizationId: organizationID.String()})
 	if err != nil {
@@ -399,7 +404,7 @@ func TestResolveModelReturnsProviderDetails(t *testing.T) {
 		getWithTokenProtocol: provider.ProtocolAnthropicMessages,
 	}
 	models := &fakeModelStore{getModel: model.Model{ProviderID: providerID, RemoteName: "remote", OrganizationID: organizationID, Name: "model"}}
-	server := New(providers, models)
+	server := newTestServer(providers, models)
 
 	resp, err := server.ResolveModel(context.Background(), &llmv1.ResolveModelRequest{ModelId: modelID.String()})
 	if err != nil {

--- a/internal/grpcserver/test_model.go
+++ b/internal/grpcserver/test_model.go
@@ -27,7 +27,9 @@ const (
 	testModelMaxErrorBodyBytes          = 1024
 )
 
-var testModelHTTPClient = &http.Client{}
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
 
 type testModelError struct {
 	code    codes.Code
@@ -107,7 +109,7 @@ func (s *Server) TestModel(ctx context.Context, req *llmv1.TestModelRequest) (*l
 		return nil, statusErrorForTestModel(err)
 	}
 
-	outputText, err := testModel(ctx, input)
+	outputText, err := testModel(ctx, s.httpClient, input)
 	if err != nil {
 		return nil, statusErrorForTestModel(err)
 	}
@@ -154,7 +156,7 @@ func newTestModelInput(mdl model.Model, prov provider.ProviderWithToken) (testMo
 	}, nil
 }
 
-func testModel(ctx context.Context, input testModelInput) (string, error) {
+func testModel(ctx context.Context, httpClient HTTPClient, input testModelInput) (string, error) {
 	body, headers, err := buildTestModelRequest(input)
 	if err != nil {
 		return "", err
@@ -169,7 +171,7 @@ func testModel(ctx context.Context, input testModelInput) (string, error) {
 	}
 	request.Header = headers
 
-	response, err := testModelHTTPClient.Do(request)
+	response, err := httpClient.Do(request)
 	if err != nil {
 		return "", newTestModelError(codes.Unavailable, fmt.Sprintf("request failed: %v", err))
 	}
@@ -295,7 +297,24 @@ func formatUpstreamError(statusCode int, responseBody []byte) string {
 		return fmt.Sprintf("request failed with status %d", statusCode)
 	}
 	if len(trimmed) > testModelMaxErrorBodyBytes {
-		trimmed = trimmed[:testModelMaxErrorBodyBytes] + "..."
+		trimmed = truncateUTF8(trimmed, testModelMaxErrorBodyBytes) + "..."
 	}
 	return fmt.Sprintf("request failed with status %d: %s", statusCode, trimmed)
+}
+
+func truncateUTF8(value string, maxBytes int) string {
+	if maxBytes <= 0 || value == "" {
+		return ""
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+	cutoff := 0
+	for i := range value {
+		if i > maxBytes {
+			break
+		}
+		cutoff = i
+	}
+	return value[:cutoff]
 }

--- a/internal/grpcserver/test_model.go
+++ b/internal/grpcserver/test_model.go
@@ -1,0 +1,301 @@
+package grpcserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	llmv1 "github.com/agynio/llm/.gen/go/agynio/api/llm/v1"
+	"github.com/agynio/llm/internal/model"
+	"github.com/agynio/llm/internal/provider"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	testModelPrompt                     = "Hello, world"
+	testModelTimeout                    = 30 * time.Second
+	testModelAnthropicHeader            = "2023-06-01"
+	testModelAnthropicMaxTokens         = 256
+	testModelMaxResponseBodyBytes int64 = 64 * 1024
+	testModelMaxErrorBodyBytes          = 1024
+)
+
+var testModelHTTPClient = &http.Client{}
+
+type testModelError struct {
+	code    codes.Code
+	message string
+}
+
+func (e *testModelError) Error() string {
+	return e.message
+}
+
+func newTestModelError(code codes.Code, message string) *testModelError {
+	return &testModelError{code: code, message: message}
+}
+
+type testModelInput struct {
+	endpoint   string
+	token      string
+	remoteName string
+	protocol   provider.Protocol
+	authMethod provider.AuthMethod
+}
+
+type responsesRequest struct {
+	Model string `json:"model"`
+	Input string `json:"input"`
+}
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	Messages  []anthropicMessage `json:"messages"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type responsesResponse struct {
+	Output []responsesOutput `json:"output"`
+}
+
+type responsesOutput struct {
+	Content []responsesContent `json:"content"`
+}
+
+type responsesContent struct {
+	Text string `json:"text"`
+}
+
+type anthropicResponse struct {
+	Content []anthropicContent `json:"content"`
+}
+
+type anthropicContent struct {
+	Text string `json:"text"`
+}
+
+func (s *Server) TestModel(ctx context.Context, req *llmv1.TestModelRequest) (*llmv1.TestModelResponse, error) {
+	modelID, err := parseUUID(req.GetModelId(), "model_id")
+	if err != nil {
+		return nil, err
+	}
+
+	mdl, err := s.models.Get(ctx, modelID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	prov, err := s.providers.GetWithToken(ctx, mdl.ProviderID)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+
+	input, err := newTestModelInput(mdl, prov)
+	if err != nil {
+		return nil, statusErrorForTestModel(err)
+	}
+
+	outputText, err := testModel(ctx, input)
+	if err != nil {
+		return nil, statusErrorForTestModel(err)
+	}
+
+	return &llmv1.TestModelResponse{OutputText: outputText}, nil
+}
+
+func newTestModelInput(mdl model.Model, prov provider.ProviderWithToken) (testModelInput, error) {
+	endpoint := strings.TrimSpace(prov.Endpoint)
+	if endpoint == "" {
+		return testModelInput{}, newTestModelError(codes.FailedPrecondition, "model endpoint missing")
+	}
+
+	remoteName := strings.TrimSpace(mdl.RemoteName)
+	if remoteName == "" {
+		return testModelInput{}, newTestModelError(codes.FailedPrecondition, "model remote name missing")
+	}
+
+	protocol := prov.Protocol
+	switch protocol {
+	case provider.ProtocolResponses, provider.ProtocolAnthropicMessages:
+	default:
+		return testModelInput{}, newTestModelError(codes.FailedPrecondition, "unsupported model protocol")
+	}
+
+	authMethod := prov.AuthMethod
+	switch authMethod {
+	case provider.AuthMethodBearer, provider.AuthMethodXAPIKey:
+	default:
+		return testModelInput{}, newTestModelError(codes.FailedPrecondition, "unsupported auth method")
+	}
+
+	token := strings.TrimSpace(prov.Token)
+	if token == "" {
+		return testModelInput{}, newTestModelError(codes.FailedPrecondition, "model token missing")
+	}
+
+	return testModelInput{
+		endpoint:   endpoint,
+		token:      token,
+		remoteName: remoteName,
+		protocol:   protocol,
+		authMethod: authMethod,
+	}, nil
+}
+
+func testModel(ctx context.Context, input testModelInput) (string, error) {
+	body, headers, err := buildTestModelRequest(input)
+	if err != nil {
+		return "", err
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, testModelTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodPost, input.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", newTestModelError(codes.FailedPrecondition, fmt.Sprintf("invalid request: %v", err))
+	}
+	request.Header = headers
+
+	response, err := testModelHTTPClient.Do(request)
+	if err != nil {
+		return "", newTestModelError(codes.Unavailable, fmt.Sprintf("request failed: %v", err))
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(io.LimitReader(response.Body, testModelMaxResponseBodyBytes))
+	if err != nil {
+		return "", newTestModelError(codes.Unavailable, fmt.Sprintf("failed to read response: %v", err))
+	}
+
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return "", newTestModelError(codes.Unavailable, formatUpstreamError(response.StatusCode, responseBody))
+	}
+
+	outputText, err := parseTestModelOutput(input.protocol, responseBody)
+	if err != nil {
+		return "", newTestModelError(codes.Unavailable, err.Error())
+	}
+
+	return outputText, nil
+}
+
+func buildTestModelRequest(input testModelInput) ([]byte, http.Header, error) {
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+
+	if input.protocol == provider.ProtocolAnthropicMessages {
+		headers.Set("anthropic-version", testModelAnthropicHeader)
+	}
+
+	switch input.authMethod {
+	case provider.AuthMethodBearer:
+		headers.Set("Authorization", fmt.Sprintf("Bearer %s", input.token))
+	case provider.AuthMethodXAPIKey:
+		headers.Set("x-api-key", input.token)
+	default:
+		panic("unreachable auth method")
+	}
+
+	var payload any
+	switch input.protocol {
+	case provider.ProtocolResponses:
+		payload = responsesRequest{Model: input.remoteName, Input: testModelPrompt}
+	case provider.ProtocolAnthropicMessages:
+		payload = anthropicRequest{
+			Model:     input.remoteName,
+			MaxTokens: testModelAnthropicMaxTokens,
+			Messages: []anthropicMessage{
+				{Role: "user", Content: testModelPrompt},
+			},
+		}
+	default:
+		panic("unreachable model protocol")
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, nil, newTestModelError(codes.Internal, fmt.Sprintf("failed to encode request: %v", err))
+	}
+
+	return body, headers, nil
+}
+
+func statusErrorForTestModel(err error) error {
+	if err == nil {
+		panic("test model error is nil")
+	}
+	var testErr *testModelError
+	if errors.As(err, &testErr) {
+		return status.Error(testErr.code, testErr.message)
+	}
+	return status.Error(codes.Internal, err.Error())
+}
+
+func parseTestModelOutput(protocol provider.Protocol, responseBody []byte) (string, error) {
+	switch protocol {
+	case provider.ProtocolResponses:
+		return parseResponsesOutput(responseBody)
+	case provider.ProtocolAnthropicMessages:
+		return parseAnthropicOutput(responseBody)
+	default:
+		panic("unreachable model protocol")
+	}
+}
+
+func parseResponsesOutput(responseBody []byte) (string, error) {
+	var payload responsesResponse
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return "", fmt.Errorf("failed to parse responses output: %w", err)
+	}
+
+	for _, output := range payload.Output {
+		for _, content := range output.Content {
+			text := strings.TrimSpace(content.Text)
+			if text != "" {
+				return text, nil
+			}
+		}
+	}
+
+	return "", errors.New("response output text missing")
+}
+
+func parseAnthropicOutput(responseBody []byte) (string, error) {
+	var payload anthropicResponse
+	if err := json.Unmarshal(responseBody, &payload); err != nil {
+		return "", fmt.Errorf("failed to parse anthropic output: %w", err)
+	}
+
+	for _, content := range payload.Content {
+		text := strings.TrimSpace(content.Text)
+		if text != "" {
+			return text, nil
+		}
+	}
+
+	return "", errors.New("response output text missing")
+}
+
+func formatUpstreamError(statusCode int, responseBody []byte) string {
+	trimmed := strings.TrimSpace(string(responseBody))
+	if trimmed == "" {
+		return fmt.Sprintf("request failed with status %d", statusCode)
+	}
+	if len(trimmed) > testModelMaxErrorBodyBytes {
+		trimmed = trimmed[:testModelMaxErrorBodyBytes] + "..."
+	}
+	return fmt.Sprintf("request failed with status %d: %s", statusCode, trimmed)
+}

--- a/internal/grpcserver/test_model_test.go
+++ b/internal/grpcserver/test_model_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/agynio/llm/internal/model"
 	"github.com/agynio/llm/internal/provider"
@@ -219,6 +220,22 @@ func TestParseResponsesOutput(t *testing.T) {
 	}
 }
 
+func TestParseResponsesOutputEmpty(t *testing.T) {
+	body, err := json.Marshal(responsesResponse{
+		Output: []responsesOutput{{Content: []responsesContent{{Text: "  "}}}},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal response: %v", err)
+	}
+	_, err = parseResponsesOutput(body)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if err.Error() != "response output text missing" {
+		t.Fatalf("expected missing output error, got %q", err.Error())
+	}
+}
+
 func TestParseAnthropicOutput(t *testing.T) {
 	body, err := json.Marshal(anthropicResponse{
 		Content: []anthropicContent{
@@ -239,7 +256,7 @@ func TestParseAnthropicOutput(t *testing.T) {
 }
 
 func TestFormatUpstreamErrorTruncates(t *testing.T) {
-	body := strings.Repeat("a", testModelMaxErrorBodyBytes+10)
+	body := strings.Repeat("✓", (testModelMaxErrorBodyBytes/3)+10)
 	message := formatUpstreamError(http.StatusBadGateway, []byte(body))
 	prefix := fmt.Sprintf("request failed with status %d: ", http.StatusBadGateway)
 	if !strings.HasPrefix(message, prefix) {
@@ -249,8 +266,15 @@ func TestFormatUpstreamErrorTruncates(t *testing.T) {
 	if !strings.HasSuffix(trimmed, "...") {
 		t.Fatalf("expected truncated message suffix")
 	}
-	if len(trimmed) != testModelMaxErrorBodyBytes+3 {
-		t.Fatalf("expected trimmed length %d, got %d", testModelMaxErrorBodyBytes+3, len(trimmed))
+	trimmedContent := strings.TrimSuffix(trimmed, "...")
+	if len(trimmedContent) > testModelMaxErrorBodyBytes {
+		t.Fatalf("expected trimmed length <= %d, got %d", testModelMaxErrorBodyBytes, len(trimmedContent))
+	}
+	if trimmedContent == "" {
+		t.Fatalf("expected truncated content to be non-empty")
+	}
+	if !utf8.ValidString(trimmedContent) {
+		t.Fatalf("expected valid UTF-8 content")
 	}
 }
 
@@ -321,7 +345,7 @@ func TestTestModelSuccessResponses(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	output, err := testModel(ctx, testModelInput{
+	output, err := testModel(ctx, server.Client(), testModelInput{
 		endpoint:   server.URL,
 		remoteName: "remote",
 		token:      "token",
@@ -338,5 +362,139 @@ func TestTestModelSuccessResponses(t *testing.T) {
 	case err := <-errCh:
 		t.Fatalf("server validation failed: %v", err)
 	default:
+	}
+}
+
+func TestTestModelSuccessAnthropic(t *testing.T) {
+	errCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			select {
+			case errCh <- fmt.Errorf("expected POST, got %s", r.Method):
+			default:
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("x-api-key"); got != "token" {
+			select {
+			case errCh <- fmt.Errorf("expected x-api-key, got %q", got):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("anthropic-version"); got != testModelAnthropicHeader {
+			select {
+			case errCh <- fmt.Errorf("expected anthropic version, got %q", got):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			select {
+			case errCh <- fmt.Errorf("expected content type, got %q", got):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			select {
+			case errCh <- fmt.Errorf("failed to read body: %v", err):
+			default:
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var payload anthropicRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			select {
+			case errCh <- fmt.Errorf("invalid payload: %v", err):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if payload.Model != "remote" || payload.MaxTokens != testModelAnthropicMaxTokens {
+			select {
+			case errCh <- fmt.Errorf("unexpected payload: %#v", payload):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if len(payload.Messages) != 1 || payload.Messages[0].Role != "user" || payload.Messages[0].Content != testModelPrompt {
+			select {
+			case errCh <- fmt.Errorf("unexpected messages: %#v", payload.Messages):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(anthropicResponse{
+			Content: []anthropicContent{{Text: "ok"}},
+		}); err != nil {
+			select {
+			case errCh <- fmt.Errorf("failed to write response: %v", err):
+			default:
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	output, err := testModel(ctx, server.Client(), testModelInput{
+		endpoint:   server.URL,
+		remoteName: "remote",
+		token:      "token",
+		protocol:   provider.ProtocolAnthropicMessages,
+		authMethod: provider.AuthMethodXAPIKey,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output != "ok" {
+		t.Fatalf("expected output to match, got %q", output)
+	}
+	select {
+	case err := <-errCh:
+		t.Fatalf("server validation failed: %v", err)
+	default:
+	}
+}
+
+func TestTestModelErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, err := testModel(ctx, server.Client(), testModelInput{
+		endpoint:   server.URL,
+		remoteName: "remote",
+		token:      "token",
+		protocol:   provider.ProtocolResponses,
+		authMethod: provider.AuthMethodBearer,
+	})
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	var testErr *testModelError
+	if !errors.As(err, &testErr) {
+		t.Fatalf("expected testModelError, got %T", err)
+	}
+	if testErr.code != codes.Unavailable {
+		t.Fatalf("expected code %v, got %v", codes.Unavailable, testErr.code)
+	}
+	if testErr.message != "request failed with status 502: nope" {
+		t.Fatalf("unexpected message %q", testErr.message)
 	}
 }

--- a/internal/grpcserver/test_model_test.go
+++ b/internal/grpcserver/test_model_test.go
@@ -1,0 +1,342 @@
+package grpcserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agynio/llm/internal/model"
+	"github.com/agynio/llm/internal/provider"
+	"google.golang.org/grpc/codes"
+)
+
+func TestNewTestModelInputSuccess(t *testing.T) {
+	input, err := newTestModelInput(
+		model.Model{RemoteName: "remote-model"},
+		provider.ProviderWithToken{
+			Provider: provider.Provider{
+				Endpoint:   "https://example.com",
+				Protocol:   provider.ProtocolResponses,
+				AuthMethod: provider.AuthMethodBearer,
+			},
+			Token: "token",
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if input.endpoint != "https://example.com" {
+		t.Fatalf("expected endpoint to be set")
+	}
+	if input.remoteName != "remote-model" {
+		t.Fatalf("expected remote name to be set")
+	}
+	if input.protocol != provider.ProtocolResponses {
+		t.Fatalf("expected protocol to be set")
+	}
+	if input.authMethod != provider.AuthMethodBearer {
+		t.Fatalf("expected auth method to be set")
+	}
+	if input.token != "token" {
+		t.Fatalf("expected token to be set")
+	}
+}
+
+func TestNewTestModelInputErrors(t *testing.T) {
+	baseModel := func() model.Model {
+		return model.Model{RemoteName: "remote-model"}
+	}
+	baseProvider := func() provider.ProviderWithToken {
+		return provider.ProviderWithToken{
+			Provider: provider.Provider{
+				Endpoint:   "https://example.com",
+				Protocol:   provider.ProtocolResponses,
+				AuthMethod: provider.AuthMethodBearer,
+			},
+			Token: "token",
+		}
+	}
+
+	for _, tt := range []struct {
+		name    string
+		mutate  func(*model.Model, *provider.ProviderWithToken)
+		code    codes.Code
+		message string
+	}{
+		{
+			name: "missing endpoint",
+			mutate: func(_ *model.Model, prov *provider.ProviderWithToken) {
+				prov.Endpoint = ""
+			},
+			code:    codes.FailedPrecondition,
+			message: "model endpoint missing",
+		},
+		{
+			name: "missing remote name",
+			mutate: func(mdl *model.Model, _ *provider.ProviderWithToken) {
+				mdl.RemoteName = ""
+			},
+			code:    codes.FailedPrecondition,
+			message: "model remote name missing",
+		},
+		{
+			name: "unsupported protocol",
+			mutate: func(_ *model.Model, prov *provider.ProviderWithToken) {
+				prov.Protocol = provider.Protocol("")
+			},
+			code:    codes.FailedPrecondition,
+			message: "unsupported model protocol",
+		},
+		{
+			name: "unsupported auth method",
+			mutate: func(_ *model.Model, prov *provider.ProviderWithToken) {
+				prov.AuthMethod = provider.AuthMethod("")
+			},
+			code:    codes.FailedPrecondition,
+			message: "unsupported auth method",
+		},
+		{
+			name: "missing token",
+			mutate: func(_ *model.Model, prov *provider.ProviderWithToken) {
+				prov.Token = ""
+			},
+			code:    codes.FailedPrecondition,
+			message: "model token missing",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mdl := baseModel()
+			prov := baseProvider()
+			tt.mutate(&mdl, &prov)
+			_, err := newTestModelInput(mdl, prov)
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			var testErr *testModelError
+			if !errors.As(err, &testErr) {
+				t.Fatalf("expected testModelError, got %T", err)
+			}
+			if testErr.code != tt.code {
+				t.Fatalf("expected code %v, got %v", tt.code, testErr.code)
+			}
+			if testErr.message != tt.message {
+				t.Fatalf("expected message %q, got %q", tt.message, testErr.message)
+			}
+		})
+	}
+}
+
+func TestBuildTestModelRequestResponses(t *testing.T) {
+	body, headers, err := buildTestModelRequest(testModelInput{
+		endpoint:   "https://example.com",
+		remoteName: "remote",
+		token:      "token",
+		protocol:   provider.ProtocolResponses,
+		authMethod: provider.AuthMethodBearer,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := headers.Get("Authorization"); got != "Bearer token" {
+		t.Fatalf("expected bearer auth header, got %q", got)
+	}
+	if got := headers.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("expected content type header, got %q", got)
+	}
+	if got := headers.Get("anthropic-version"); got != "" {
+		t.Fatalf("unexpected anthropic header: %q", got)
+	}
+	var payload responsesRequest
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+	if payload.Model != "remote" {
+		t.Fatalf("expected model name to match")
+	}
+	if payload.Input != testModelPrompt {
+		t.Fatalf("expected prompt to match")
+	}
+}
+
+func TestBuildTestModelRequestAnthropic(t *testing.T) {
+	body, headers, err := buildTestModelRequest(testModelInput{
+		endpoint:   "https://example.com",
+		remoteName: "remote",
+		token:      "token",
+		protocol:   provider.ProtocolAnthropicMessages,
+		authMethod: provider.AuthMethodXAPIKey,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := headers.Get("x-api-key"); got != "token" {
+		t.Fatalf("expected x-api-key header, got %q", got)
+	}
+	if got := headers.Get("anthropic-version"); got != testModelAnthropicHeader {
+		t.Fatalf("expected anthropic version header, got %q", got)
+	}
+	var payload anthropicRequest
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("failed to parse payload: %v", err)
+	}
+	if payload.Model != "remote" {
+		t.Fatalf("expected model name to match")
+	}
+	if payload.MaxTokens != testModelAnthropicMaxTokens {
+		t.Fatalf("expected max tokens to match")
+	}
+	if len(payload.Messages) != 1 {
+		t.Fatalf("expected one message")
+	}
+	if payload.Messages[0].Role != "user" || payload.Messages[0].Content != testModelPrompt {
+		t.Fatalf("expected user prompt message")
+	}
+}
+
+func TestParseResponsesOutput(t *testing.T) {
+	body, err := json.Marshal(responsesResponse{
+		Output: []responsesOutput{
+			{Content: []responsesContent{{Text: ""}}},
+			{Content: []responsesContent{{Text: "  response  "}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal response: %v", err)
+	}
+	text, err := parseResponsesOutput(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text != "response" {
+		t.Fatalf("expected trimmed response text, got %q", text)
+	}
+}
+
+func TestParseAnthropicOutput(t *testing.T) {
+	body, err := json.Marshal(anthropicResponse{
+		Content: []anthropicContent{
+			{Text: ""},
+			{Text: "  response  "},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal response: %v", err)
+	}
+	text, err := parseAnthropicOutput(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if text != "response" {
+		t.Fatalf("expected trimmed response text, got %q", text)
+	}
+}
+
+func TestFormatUpstreamErrorTruncates(t *testing.T) {
+	body := strings.Repeat("a", testModelMaxErrorBodyBytes+10)
+	message := formatUpstreamError(http.StatusBadGateway, []byte(body))
+	prefix := fmt.Sprintf("request failed with status %d: ", http.StatusBadGateway)
+	if !strings.HasPrefix(message, prefix) {
+		t.Fatalf("expected prefix %q", prefix)
+	}
+	trimmed := strings.TrimPrefix(message, prefix)
+	if !strings.HasSuffix(trimmed, "...") {
+		t.Fatalf("expected truncated message suffix")
+	}
+	if len(trimmed) != testModelMaxErrorBodyBytes+3 {
+		t.Fatalf("expected trimmed length %d, got %d", testModelMaxErrorBodyBytes+3, len(trimmed))
+	}
+}
+
+func TestTestModelSuccessResponses(t *testing.T) {
+	errCh := make(chan error, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			select {
+			case errCh <- fmt.Errorf("expected POST, got %s", r.Method):
+			default:
+			}
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer token" {
+			select {
+			case errCh <- fmt.Errorf("expected bearer auth, got %q", got):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			select {
+			case errCh <- fmt.Errorf("expected content type, got %q", got):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			select {
+			case errCh <- fmt.Errorf("failed to read body: %v", err):
+			default:
+			}
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var payload responsesRequest
+		if err := json.Unmarshal(body, &payload); err != nil {
+			select {
+			case errCh <- fmt.Errorf("invalid payload: %v", err):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if payload.Model != "remote" || payload.Input != testModelPrompt {
+			select {
+			case errCh <- fmt.Errorf("unexpected payload: %#v", payload):
+			default:
+			}
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(responsesResponse{
+			Output: []responsesOutput{{Content: []responsesContent{{Text: "ok"}}}},
+		}); err != nil {
+			select {
+			case errCh <- fmt.Errorf("failed to write response: %v", err):
+			default:
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	output, err := testModel(ctx, testModelInput{
+		endpoint:   server.URL,
+		remoteName: "remote",
+		token:      "token",
+		protocol:   provider.ProtocolResponses,
+		authMethod: provider.AuthMethodBearer,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output != "ok" {
+		t.Fatalf("expected output to match, got %q", output)
+	}
+	select {
+	case err := <-errCh:
+		t.Fatalf("server validation failed: %v", err)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary
- add LLMService.TestModel implementation with provider callout
- validate model/provider inputs and parse protocol-specific outputs
- add unit tests for request/response handling

## Testing
- go vet ./...
- go test ./...

Refs https://github.com/agynio/console-app/issues/49