### PR TITLE
feat(auth): enforce llm authz

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf stubs
-        run: buf generate buf.build/agynio/api --path agynio/api/llm/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/authorization/v1
 
       - name: Go vet
         run: go vet ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN buf generate buf.build/agynio/api --path agynio/api/llm/v1
+RUN buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/authorization/v1
 
 COPY . .
 

--- a/charts/llm/templates/_helpers.tpl
+++ b/charts/llm/templates/_helpers.tpl
@@ -5,6 +5,10 @@
 {{- if $grpcAddress }}
 {{- $env = append $env (dict "name" "GRPC_ADDRESS" "value" $grpcAddress) -}}
 {{- end }}
+{{- $authorizationAddress := trimAll " \n\t" (default "authorization:50051" .Values.llm.authorizationAddress) -}}
+{{- if $authorizationAddress }}
+{{- $env = append $env (dict "name" "AUTHORIZATION_ADDRESS" "value" $authorizationAddress) -}}
+{{- end }}
 {{- $dbSecret := trim (default "" .Values.llm.databaseUrl.existingSecret) -}}
 {{- $dbVar := dict "name" "DATABASE_URL" -}}
 {{- if $dbSecret }}

--- a/charts/llm/values.yaml
+++ b/charts/llm/values.yaml
@@ -147,6 +147,7 @@ metrics:
 
 llm:
   grpcAddress: ":50051"
+  authorizationAddress: "authorization:50051"
   databaseUrl:
     value: ""
     existingSecret: ""

--- a/cmd/llm/main.go
+++ b/cmd/llm/main.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	authorizationv1 "github.com/agynio/llm/.gen/go/agynio/api/authorization/v1"
 	llmv1 "github.com/agynio/llm/.gen/go/agynio/api/llm/v1"
 	"github.com/agynio/llm/internal/config"
 	"github.com/agynio/llm/internal/db"
@@ -20,6 +21,7 @@ import (
 	"github.com/agynio/llm/internal/provider"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -57,13 +59,18 @@ func run() error {
 
 	providerStore := provider.NewStore(pool)
 	modelStore := model.NewStore(pool)
+	authorizationConn, err := grpc.DialContext(ctx, cfg.AuthorizationAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial authorization: %w", err)
+	}
+	defer authorizationConn.Close()
 
 	grpcServer := grpc.NewServer()
 	healthServer := health.NewServer()
 	healthpb.RegisterHealthServer(grpcServer, healthServer)
 	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	healthServer.SetServingStatus("agynio.api.llm.v1.LLMService", healthpb.HealthCheckResponse_SERVING)
-	llmv1.RegisterLLMServiceServer(grpcServer, grpcserver.New(providerStore, modelStore, http.DefaultClient))
+	llmv1.RegisterLLMServiceServer(grpcServer, grpcserver.New(providerStore, modelStore, authorizationv1.NewAuthorizationServiceClient(authorizationConn), http.DefaultClient))
 
 	grpcListener, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,12 +7,14 @@ import (
 )
 
 const (
-	defaultGRPCAddress = ":50051"
+	defaultGRPCAddress          = ":50051"
+	defaultAuthorizationAddress = "authorization:50051"
 )
 
 type Config struct {
-	GRPCAddress string
-	DatabaseURL string
+	GRPCAddress          string
+	AuthorizationAddress string
+	DatabaseURL          string
 }
 
 func FromEnv() (Config, error) {
@@ -21,6 +23,10 @@ func FromEnv() (Config, error) {
 	cfg.GRPCAddress = strings.TrimSpace(os.Getenv("GRPC_ADDRESS"))
 	if cfg.GRPCAddress == "" {
 		cfg.GRPCAddress = defaultGRPCAddress
+	}
+	cfg.AuthorizationAddress = strings.TrimSpace(os.Getenv("AUTHORIZATION_ADDRESS"))
+	if cfg.AuthorizationAddress == "" {
+		cfg.AuthorizationAddress = defaultAuthorizationAddress
 	}
 	var err error
 	cfg.DatabaseURL, err = requiredEnv("DATABASE_URL")

--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"strings"
 
+	authorizationv1 "github.com/agynio/llm/.gen/go/agynio/api/authorization/v1"
 	llmv1 "github.com/agynio/llm/.gen/go/agynio/api/llm/v1"
 	"github.com/agynio/llm/internal/identity"
 	"github.com/agynio/llm/internal/model"
 	"github.com/agynio/llm/internal/provider"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -33,23 +35,45 @@ type ModelStore interface {
 	List(ctx context.Context, organizationID uuid.UUID, filter model.ListFilter, pageSize int32, cursor *model.PageCursor) (model.ListResult, error)
 }
 
-type Server struct {
-	llmv1.UnimplementedLLMServiceServer
-	providers ProviderStore
-	models    ModelStore
-	httpClient HTTPClient
+type authorizationClient interface {
+	Check(ctx context.Context, in *authorizationv1.CheckRequest, opts ...grpc.CallOption) (*authorizationv1.CheckResponse, error)
+	Write(ctx context.Context, in *authorizationv1.WriteRequest, opts ...grpc.CallOption) (*authorizationv1.WriteResponse, error)
 }
 
-func New(providers ProviderStore, models ModelStore, httpClient HTTPClient) *Server {
+type Server struct {
+	llmv1.UnimplementedLLMServiceServer
+	providers     ProviderStore
+	models        ModelStore
+	authorization authorizationClient
+	httpClient    HTTPClient
+}
+
+const (
+	identityObjectPrefix     = "identity:"
+	organizationObjectPrefix = "organization:"
+	modelObjectPrefix        = "model:"
+)
+
+func New(providers ProviderStore, models ModelStore, authorization authorizationClient, httpClient HTTPClient) *Server {
+	if authorization == nil {
+		panic("authorization client is required")
+	}
 	if httpClient == nil {
 		panic("http client is required")
 	}
-	return &Server{providers: providers, models: models, httpClient: httpClient}
+	return &Server{providers: providers, models: models, authorization: authorization, httpClient: httpClient}
 }
 
 func (s *Server) CreateLLMProvider(ctx context.Context, req *llmv1.CreateLLMProviderRequest) (*llmv1.CreateLLMProviderResponse, error) {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	organizationID, err := parseUUID(req.GetOrganizationId(), "organization_id")
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireOrgOwner(ctx, caller.IdentityID, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -85,7 +109,8 @@ func (s *Server) CreateLLMProvider(ctx context.Context, req *llmv1.CreateLLMProv
 }
 
 func (s *Server) GetLLMProvider(ctx context.Context, req *llmv1.GetLLMProviderRequest) (*llmv1.GetLLMProviderResponse, error) {
-	if _, err := identity.FromContext(ctx); err != nil {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -97,16 +122,27 @@ func (s *Server) GetLLMProvider(ctx context.Context, req *llmv1.GetLLMProviderRe
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireOrgMember(ctx, caller.IdentityID, prov.OrganizationID); err != nil {
+		return nil, err
+	}
 	return &llmv1.GetLLMProviderResponse{Provider: toProtoProvider(prov)}, nil
 }
 
 func (s *Server) UpdateLLMProvider(ctx context.Context, req *llmv1.UpdateLLMProviderRequest) (*llmv1.UpdateLLMProviderResponse, error) {
-	if _, err := identity.FromContext(ctx); err != nil {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
 		return nil, err
 	}
 
 	id, err := parseUUID(req.GetId(), "id")
 	if err != nil {
+		return nil, err
+	}
+	prov, err := s.providers.Get(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgOwner(ctx, caller.IdentityID, prov.OrganizationID); err != nil {
 		return nil, err
 	}
 
@@ -149,12 +185,20 @@ func (s *Server) UpdateLLMProvider(ctx context.Context, req *llmv1.UpdateLLMProv
 }
 
 func (s *Server) DeleteLLMProvider(ctx context.Context, req *llmv1.DeleteLLMProviderRequest) (*llmv1.DeleteLLMProviderResponse, error) {
-	if _, err := identity.FromContext(ctx); err != nil {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
 		return nil, err
 	}
 
 	id, err := parseUUID(req.GetId(), "id")
 	if err != nil {
+		return nil, err
+	}
+	prov, err := s.providers.Get(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgOwner(ctx, caller.IdentityID, prov.OrganizationID); err != nil {
 		return nil, err
 	}
 	if err := s.providers.Delete(ctx, id); err != nil {
@@ -164,8 +208,15 @@ func (s *Server) DeleteLLMProvider(ctx context.Context, req *llmv1.DeleteLLMProv
 }
 
 func (s *Server) ListLLMProviders(ctx context.Context, req *llmv1.ListLLMProvidersRequest) (*llmv1.ListLLMProvidersResponse, error) {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	organizationID, err := parseUUID(req.GetOrganizationId(), "organization_id")
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireOrgMember(ctx, caller.IdentityID, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -201,8 +252,15 @@ func (s *Server) ListLLMProviders(ctx context.Context, req *llmv1.ListLLMProvide
 }
 
 func (s *Server) CreateModel(ctx context.Context, req *llmv1.CreateModelRequest) (*llmv1.CreateModelResponse, error) {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	organizationID, err := parseUUID(req.GetOrganizationId(), "organization_id")
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireOrgOwner(ctx, caller.IdentityID, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -228,12 +286,16 @@ func (s *Server) CreateModel(ctx context.Context, req *llmv1.CreateModelRequest)
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.writeModelTuple(ctx, organizationID, created.ID); err != nil {
+		return nil, err
+	}
 
 	return &llmv1.CreateModelResponse{Model: toProtoModel(created)}, nil
 }
 
 func (s *Server) GetModel(ctx context.Context, req *llmv1.GetModelRequest) (*llmv1.GetModelResponse, error) {
-	if _, err := identity.FromContext(ctx); err != nil {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -245,16 +307,27 @@ func (s *Server) GetModel(ctx context.Context, req *llmv1.GetModelRequest) (*llm
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireOrgMember(ctx, caller.IdentityID, mdl.OrganizationID); err != nil {
+		return nil, err
+	}
 	return &llmv1.GetModelResponse{Model: toProtoModel(mdl)}, nil
 }
 
 func (s *Server) UpdateModel(ctx context.Context, req *llmv1.UpdateModelRequest) (*llmv1.UpdateModelResponse, error) {
-	if _, err := identity.FromContext(ctx); err != nil {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
 		return nil, err
 	}
 
 	id, err := parseUUID(req.GetId(), "id")
 	if err != nil {
+		return nil, err
+	}
+	mdl, err := s.models.Get(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgOwner(ctx, caller.IdentityID, mdl.OrganizationID); err != nil {
 		return nil, err
 	}
 	input := model.UpdateInput{ID: id}
@@ -289,7 +362,8 @@ func (s *Server) UpdateModel(ctx context.Context, req *llmv1.UpdateModelRequest)
 }
 
 func (s *Server) DeleteModel(ctx context.Context, req *llmv1.DeleteModelRequest) (*llmv1.DeleteModelResponse, error) {
-	if _, err := identity.FromContext(ctx); err != nil {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
 		return nil, err
 	}
 
@@ -297,15 +371,32 @@ func (s *Server) DeleteModel(ctx context.Context, req *llmv1.DeleteModelRequest)
 	if err != nil {
 		return nil, err
 	}
+	mdl, err := s.models.Get(ctx, id)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgOwner(ctx, caller.IdentityID, mdl.OrganizationID); err != nil {
+		return nil, err
+	}
 	if err := s.models.Delete(ctx, id); err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.deleteModelTuple(ctx, mdl.OrganizationID, mdl.ID); err != nil {
+		return nil, err
 	}
 	return &llmv1.DeleteModelResponse{}, nil
 }
 
 func (s *Server) ListModels(ctx context.Context, req *llmv1.ListModelsRequest) (*llmv1.ListModelsResponse, error) {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	organizationID, err := parseUUID(req.GetOrganizationId(), "organization_id")
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireOrgMember(ctx, caller.IdentityID, organizationID); err != nil {
 		return nil, err
 	}
 
@@ -489,4 +580,61 @@ func toStatusError(err error) error {
 		return status.Error(codes.FailedPrecondition, err.Error())
 	}
 	return status.Error(codes.Internal, err.Error())
+}
+
+func (s *Server) requireOrgOwner(ctx context.Context, identityID string, organizationID uuid.UUID) error {
+	return s.requireOrgRelation(ctx, identityID, organizationID, "owner")
+}
+
+func (s *Server) requireOrgMember(ctx context.Context, identityID string, organizationID uuid.UUID) error {
+	return s.requireOrgRelation(ctx, identityID, organizationID, "member")
+}
+
+func (s *Server) requireOrgRelation(ctx context.Context, identityID string, organizationID uuid.UUID, relation string) error {
+	resp, err := s.authorization.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     fmt.Sprintf("%s%s", identityObjectPrefix, identityID),
+			Relation: relation,
+			Object:   fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+		},
+	})
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization check: %v", err)
+	}
+	if !resp.GetAllowed() {
+		return status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return nil
+}
+
+func (s *Server) writeModelTuple(ctx context.Context, organizationID uuid.UUID, modelID uuid.UUID) error {
+	_, err := s.authorization.Write(ctx, &authorizationv1.WriteRequest{
+		Writes: []*authorizationv1.TupleKey{
+			{
+				User:     fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+				Relation: "org",
+				Object:   fmt.Sprintf("%s%s", modelObjectPrefix, modelID.String()),
+			},
+		},
+	})
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization write: %v", err)
+	}
+	return nil
+}
+
+func (s *Server) deleteModelTuple(ctx context.Context, organizationID uuid.UUID, modelID uuid.UUID) error {
+	_, err := s.authorization.Write(ctx, &authorizationv1.WriteRequest{
+		Deletes: []*authorizationv1.TupleKey{
+			{
+				User:     fmt.Sprintf("%s%s", organizationObjectPrefix, organizationID.String()),
+				Relation: "org",
+				Object:   fmt.Sprintf("%s%s", modelObjectPrefix, modelID.String()),
+			},
+		},
+	})
+	if err != nil {
+		return status.Errorf(codes.Internal, "authorization write: %v", err)
+	}
+	return nil
 }

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -10,11 +10,13 @@ import (
 	"testing"
 	"time"
 
+	authorizationv1 "github.com/agynio/llm/.gen/go/agynio/api/authorization/v1"
 	llmv1 "github.com/agynio/llm/.gen/go/agynio/api/llm/v1"
 	"github.com/agynio/llm/internal/identity"
 	"github.com/agynio/llm/internal/model"
 	"github.com/agynio/llm/internal/provider"
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -178,6 +180,29 @@ func (f *fakeModelStore) List(ctx context.Context, organizationID uuid.UUID, fil
 	return model.ListResult{Models: []model.Model{}}, nil
 }
 
+type fakeAuthorizationClient struct {
+	checkFn       func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error)
+	writeFn       func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error)
+	checkRequests []*authorizationv1.CheckRequest
+	writeRequests []*authorizationv1.WriteRequest
+}
+
+func (f *fakeAuthorizationClient) Check(ctx context.Context, req *authorizationv1.CheckRequest, _ ...grpc.CallOption) (*authorizationv1.CheckResponse, error) {
+	f.checkRequests = append(f.checkRequests, req)
+	if f.checkFn != nil {
+		return f.checkFn(ctx, req)
+	}
+	return &authorizationv1.CheckResponse{Allowed: true}, nil
+}
+
+func (f *fakeAuthorizationClient) Write(ctx context.Context, req *authorizationv1.WriteRequest, _ ...grpc.CallOption) (*authorizationv1.WriteResponse, error) {
+	f.writeRequests = append(f.writeRequests, req)
+	if f.writeFn != nil {
+		return f.writeFn(ctx, req)
+	}
+	return &authorizationv1.WriteResponse{}, nil
+}
+
 func contextWithIdentity() context.Context {
 	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(
 		identity.MetadataKeyIdentityID, "identity-1",
@@ -186,7 +211,7 @@ func contextWithIdentity() context.Context {
 }
 
 func newTestServer(providers ProviderStore, models ModelStore) *Server {
-	return New(providers, models, http.DefaultClient)
+	return New(providers, models, &fakeAuthorizationClient{}, http.DefaultClient)
 }
 
 func TestCreateLLMProviderUsesOrganizationID(t *testing.T) {
@@ -194,7 +219,7 @@ func TestCreateLLMProviderUsesOrganizationID(t *testing.T) {
 	providers := &fakeProviderStore{}
 	server := newTestServer(providers, &fakeModelStore{})
 
-	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
+	_, err := server.CreateLLMProvider(contextWithIdentity(), &llmv1.CreateLLMProviderRequest{
 		Endpoint:       "https://example.com",
 		Token:          "token",
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
@@ -219,7 +244,7 @@ func TestCreateLLMProviderDefaultsProtocol(t *testing.T) {
 	providers := &fakeProviderStore{}
 	server := newTestServer(providers, &fakeModelStore{})
 
-	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
+	_, err := server.CreateLLMProvider(contextWithIdentity(), &llmv1.CreateLLMProviderRequest{
 		Endpoint:       "https://example.com",
 		Token:          "token",
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
@@ -240,7 +265,7 @@ func TestCreateLLMProviderSupportsXAPIKey(t *testing.T) {
 	server := newTestServer(providers, &fakeModelStore{})
 	protocol := llmv1.Protocol_PROTOCOL_ANTHROPIC_MESSAGES
 
-	_, err := server.CreateLLMProvider(context.Background(), &llmv1.CreateLLMProviderRequest{
+	_, err := server.CreateLLMProvider(contextWithIdentity(), &llmv1.CreateLLMProviderRequest{
 		Endpoint:       "https://example.com",
 		Token:          "token",
 		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_X_API_KEY,
@@ -255,6 +280,36 @@ func TestCreateLLMProviderSupportsXAPIKey(t *testing.T) {
 	}
 	if providers.createProtocol != provider.ProtocolAnthropicMessages {
 		t.Fatalf("expected protocol %s, got %s", provider.ProtocolAnthropicMessages, providers.createProtocol)
+	}
+}
+
+func TestCreateLLMProviderAuthorizationDenied(t *testing.T) {
+	organizationID := uuid.MustParse("6a34b377-3fbb-4dbf-91c4-b14925ac7d7c")
+	providers := &fakeProviderStore{}
+	authorization := &fakeAuthorizationClient{
+		checkFn: func(_ context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			if req.GetTupleKey().GetRelation() != "owner" {
+				t.Fatalf("expected relation owner, got %s", req.GetTupleKey().GetRelation())
+			}
+			if req.GetTupleKey().GetObject() != "organization:"+organizationID.String() {
+				t.Fatalf("unexpected object %s", req.GetTupleKey().GetObject())
+			}
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+	server := New(providers, &fakeModelStore{}, authorization, http.DefaultClient)
+
+	_, err := server.CreateLLMProvider(contextWithIdentity(), &llmv1.CreateLLMProviderRequest{
+		Endpoint:       "https://example.com",
+		Token:          "token",
+		AuthMethod:     llmv1.AuthMethod_AUTH_METHOD_BEARER,
+		OrganizationId: organizationID.String(),
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", status.Code(err))
+	}
+	if providers.createOrganizationID != uuid.Nil {
+		t.Fatalf("expected create not called")
 	}
 }
 
@@ -319,7 +374,7 @@ func TestListLLMProvidersUsesOrganizationID(t *testing.T) {
 	providers := &fakeProviderStore{}
 	server := newTestServer(providers, &fakeModelStore{})
 
-	_, err := server.ListLLMProviders(context.Background(), &llmv1.ListLLMProvidersRequest{PageSize: 5, OrganizationId: organizationID.String()})
+	_, err := server.ListLLMProviders(contextWithIdentity(), &llmv1.ListLLMProvidersRequest{PageSize: 5, OrganizationId: organizationID.String()})
 	if err != nil {
 		t.Fatalf("ListLLMProviders: %v", err)
 	}
@@ -333,7 +388,7 @@ func TestCreateModelUsesOrganizationID(t *testing.T) {
 	models := &fakeModelStore{}
 	server := newTestServer(&fakeProviderStore{}, models)
 
-	_, err := server.CreateModel(context.Background(), &llmv1.CreateModelRequest{
+	_, err := server.CreateModel(contextWithIdentity(), &llmv1.CreateModelRequest{
 		Name:           "name",
 		LlmProviderId:  uuid.MustParse("b89fc3c9-0e60-4a74-84c0-c4f1d26c1ee1").String(),
 		RemoteName:     "remote",
@@ -344,6 +399,44 @@ func TestCreateModelUsesOrganizationID(t *testing.T) {
 	}
 	if models.createOrganizationID != organizationID {
 		t.Fatalf("expected organization %s, got %s", organizationID, models.createOrganizationID)
+	}
+}
+
+func TestCreateModelWritesAuthorizationTuple(t *testing.T) {
+	organizationID := uuid.MustParse("9fd2468a-3387-48f0-9859-7eaf84f8b6d0")
+	modelID := uuid.MustParse("1bb21ea2-03c8-453b-a0ef-c4a12f0f8f2a")
+	models := &fakeModelStore{}
+	authorization := &fakeAuthorizationClient{
+		checkFn: func(_ context.Context, _ *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+		writeFn: func(_ context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+			if len(req.GetWrites()) != 1 {
+				t.Fatalf("expected 1 write, got %d", len(req.GetWrites()))
+			}
+			tuple := req.GetWrites()[0]
+			if tuple.GetUser() != "organization:"+organizationID.String() {
+				t.Fatalf("unexpected user %s", tuple.GetUser())
+			}
+			if tuple.GetRelation() != "org" {
+				t.Fatalf("unexpected relation %s", tuple.GetRelation())
+			}
+			if tuple.GetObject() != "model:"+modelID.String() {
+				t.Fatalf("unexpected object %s", tuple.GetObject())
+			}
+			return &authorizationv1.WriteResponse{}, nil
+		},
+	}
+	server := New(&fakeProviderStore{}, models, authorization, http.DefaultClient)
+
+	_, err := server.CreateModel(contextWithIdentity(), &llmv1.CreateModelRequest{
+		Name:           "name",
+		LlmProviderId:  uuid.MustParse("b89fc3c9-0e60-4a74-84c0-c4f1d26c1ee1").String(),
+		RemoteName:     "remote",
+		OrganizationId: organizationID.String(),
+	})
+	if err != nil {
+		t.Fatalf("CreateModel: %v", err)
 	}
 }
 
@@ -358,6 +451,23 @@ func TestGetModelUsesID(t *testing.T) {
 	}
 	if models.getID != modelID {
 		t.Fatalf("expected model id %s, got %s", modelID, models.getID)
+	}
+}
+
+func TestGetModelAuthorizationDenied(t *testing.T) {
+	modelID := uuid.MustParse("66c03014-4709-480f-876a-f05cbaf3a1d7")
+	organizationID := uuid.MustParse("c1f0da2f-cf7b-49ef-a821-1466dc1592a4")
+	models := &fakeModelStore{getModel: model.Model{OrganizationID: organizationID}}
+	authorization := &fakeAuthorizationClient{
+		checkFn: func(_ context.Context, _ *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: false}, nil
+		},
+	}
+	server := New(&fakeProviderStore{}, models, authorization, http.DefaultClient)
+
+	_, err := server.GetModel(contextWithIdentity(), &llmv1.GetModelRequest{Id: modelID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", status.Code(err))
 	}
 }
 
@@ -393,12 +503,45 @@ func TestDeleteModelUsesID(t *testing.T) {
 	}
 }
 
+func TestDeleteModelDeletesAuthorizationTuple(t *testing.T) {
+	modelID := uuid.MustParse("0d0243f7-7eab-49f6-8a57-bfeec466e28f")
+	organizationID := uuid.MustParse("d19a2438-ea47-4b6e-8c62-a58f71c78c9c")
+	models := &fakeModelStore{getModel: model.Model{ID: modelID, OrganizationID: organizationID}}
+	authorization := &fakeAuthorizationClient{
+		checkFn: func(_ context.Context, _ *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		},
+		writeFn: func(_ context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+			if len(req.GetDeletes()) != 1 {
+				t.Fatalf("expected 1 delete, got %d", len(req.GetDeletes()))
+			}
+			tuple := req.GetDeletes()[0]
+			if tuple.GetUser() != "organization:"+organizationID.String() {
+				t.Fatalf("unexpected user %s", tuple.GetUser())
+			}
+			if tuple.GetRelation() != "org" {
+				t.Fatalf("unexpected relation %s", tuple.GetRelation())
+			}
+			if tuple.GetObject() != "model:"+modelID.String() {
+				t.Fatalf("unexpected object %s", tuple.GetObject())
+			}
+			return &authorizationv1.WriteResponse{}, nil
+		},
+	}
+	server := New(&fakeProviderStore{}, models, authorization, http.DefaultClient)
+
+	_, err := server.DeleteModel(contextWithIdentity(), &llmv1.DeleteModelRequest{Id: modelID.String()})
+	if err != nil {
+		t.Fatalf("DeleteModel: %v", err)
+	}
+}
+
 func TestListModelsUsesOrganizationID(t *testing.T) {
 	organizationID := uuid.MustParse("0f42fd48-4d3e-4382-b787-6e681d8b82a0")
 	models := &fakeModelStore{}
 	server := newTestServer(&fakeProviderStore{}, models)
 
-	_, err := server.ListModels(context.Background(), &llmv1.ListModelsRequest{PageSize: 5, OrganizationId: organizationID.String()})
+	_, err := server.ListModels(contextWithIdentity(), &llmv1.ListModelsRequest{PageSize: 5, OrganizationId: organizationID.String()})
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
 	}
@@ -498,9 +641,9 @@ func TestTestModelReturnsOutput(t *testing.T) {
 		getWithTokenToken:    "token",
 	}
 	models := &fakeModelStore{getModel: model.Model{ProviderID: providerID, RemoteName: "remote"}}
-	service := New(providers, models, server.Client())
+	service := New(providers, models, &fakeAuthorizationClient{}, server.Client())
 
-	resp, err := service.TestModel(context.Background(), &llmv1.TestModelRequest{ModelId: modelID.String()})
+	resp, err := service.TestModel(contextWithIdentity(), &llmv1.TestModelRequest{ModelId: modelID.String()})
 	if err != nil {
 		t.Fatalf("TestModel: %v", err)
 	}

--- a/internal/grpcserver/test_model.go
+++ b/internal/grpcserver/test_model.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	llmv1 "github.com/agynio/llm/.gen/go/agynio/api/llm/v1"
+	"github.com/agynio/llm/internal/identity"
 	"github.com/agynio/llm/internal/model"
 	"github.com/agynio/llm/internal/provider"
 	"google.golang.org/grpc/codes"
@@ -89,6 +90,10 @@ type anthropicContent struct {
 }
 
 func (s *Server) TestModel(ctx context.Context, req *llmv1.TestModelRequest) (*llmv1.TestModelResponse, error) {
+	caller, err := identity.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	modelID, err := parseUUID(req.GetModelId(), "model_id")
 	if err != nil {
 		return nil, err
@@ -97,6 +102,9 @@ func (s *Server) TestModel(ctx context.Context, req *llmv1.TestModelRequest) (*l
 	mdl, err := s.models.Get(ctx, modelID)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgMember(ctx, caller.IdentityID, mdl.OrganizationID); err != nil {
+		return nil, err
 	}
 
 	prov, err := s.providers.GetWithToken(ctx, mdl.ProviderID)


### PR DESCRIPTION
## Summary
- add authorization client wiring/config and Helm env defaults
- enforce org-level authorization checks and model tuple lifecycle
- update grpcserver auth tests for tuple writes/deletes and denials

## Testing
- buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/authorization/v1
- go vet ./...
- go test ./...
- go build ./...

## Issue
- #136