### PR TITLE
Rollback model creation when authz tuple write fails

### DIFF
--- a/internal/grpcserver/server.go
+++ b/internal/grpcserver/server.go
@@ -287,6 +287,9 @@ func (s *Server) CreateModel(ctx context.Context, req *llmv1.CreateModelRequest)
 		return nil, toStatusError(err)
 	}
 	if err := s.writeModelTuple(ctx, organizationID, created.ID); err != nil {
+		if deleteErr := s.models.Delete(ctx, created.ID); deleteErr != nil {
+			return nil, status.Errorf(codes.Internal, "authorization write: %v; rollback model: %v", err, deleteErr)
+		}
 		return nil, err
 	}
 

--- a/internal/grpcserver/server_test.go
+++ b/internal/grpcserver/server_test.go
@@ -146,6 +146,7 @@ type fakeModelStore struct {
 	getModel             model.Model
 	updateID             uuid.UUID
 	deleteID             uuid.UUID
+	deleteErr            error
 }
 
 func (f *fakeModelStore) Create(ctx context.Context, input model.CreateInput) (model.Model, error) {
@@ -172,6 +173,9 @@ func (f *fakeModelStore) Update(ctx context.Context, input model.UpdateInput) (m
 
 func (f *fakeModelStore) Delete(ctx context.Context, id uuid.UUID) error {
 	f.deleteID = id
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
 	return nil
 }
 
@@ -437,6 +441,34 @@ func TestCreateModelWritesAuthorizationTuple(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateModel: %v", err)
+	}
+}
+
+func TestCreateModelRollsBackModelWhenAuthorizationWriteFails(t *testing.T) {
+	organizationID := uuid.MustParse("ba5784ff-790c-4864-b37c-a0c40e5d78d8")
+	modelID := uuid.MustParse("1bb21ea2-03c8-453b-a0ef-c4a12f0f8f2a")
+	models := &fakeModelStore{}
+	authorization := &fakeAuthorizationClient{
+		writeFn: func(_ context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+			if len(req.GetWrites()) != 1 {
+				t.Fatalf("expected 1 write, got %d", len(req.GetWrites()))
+			}
+			return nil, status.Error(codes.PermissionDenied, "authorization write denied")
+		},
+	}
+	server := New(&fakeProviderStore{}, models, authorization, http.DefaultClient)
+
+	_, err := server.CreateModel(contextWithIdentity(), &llmv1.CreateModelRequest{
+		Name:           "name",
+		LlmProviderId:  uuid.MustParse("b89fc3c9-0e60-4a74-84c0-c4f1d26c1ee1").String(),
+		RemoteName:     "remote",
+		OrganizationId: organizationID.String(),
+	})
+	if status.Code(err) != codes.Internal {
+		t.Fatalf("expected internal error, got %v", status.Code(err))
+	}
+	if models.deleteID != modelID {
+		t.Fatalf("expected rollback delete for model %s, got %s", modelID, models.deleteID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- rollback the newly created model row if `writeModelTuple` fails
- keep the expected OpenFGA tuple shape unchanged: `organization:<org_id> org model:<model_id>`
- add regression coverage for authorization write failure so a model is not left orphaned without its tuple

Closes #45

## Investigation
`CreateModel` was already calling `writeModelTuple`, so the likely prod failure mode is the authorization write returning an error after the model DB insert succeeded. Before this change, that returned an error to the caller but left the model row persisted without the OpenFGA tuple; llm-proxy could then resolve the model and deny `model#can_use`.

## E2E note
llm-proxy has DevSpace e2e tests under `test/e2e` that create a model through llm and exercise proxy authorization, but the PR CI scope in `.github/workflows/ci.yml` only runs protobuf generation, `go vet`, `go build`, and `go test ./...`. CI-enabled cross-service e2e coverage should live either in llm-proxy's existing e2e suite with a workflow that starts llm/authorization/OpenFGA/users/tenants, or in a platform-level e2e repository/workflow that owns the full service graph.

## Test & Lint Summary
- `buf generate buf.build/agynio/api --path agynio/api/llm/v1 --path agynio/api/authorization/v1` — passed.
- `go test -v ./...` — 48 passed / 0 failed / 0 skipped.
- `go vet ./...` — passed with no errors.
- `go build ./...` — passed with no errors.