### PR TITLE
ci(e2e): provision the platform VM instead of bootstrap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,101 +8,29 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
     env:
       CHART_DIR: charts/llm
-      CHART_REGISTRY: oci://ghcr.io/agynio/charts
-      IMAGE_NAME: ghcr.io/agynio/llm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Determine PR artifact versions
-        id: artifact
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          set -euo pipefail
-          base_version="$(grep '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}')"
-          chart_version="${base_version}-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}.${{ github.run_attempt }}"
-          image_tag="pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
-          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
-          echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push PR image
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ steps.artifact.outputs.image_tag }}
-          cache-from: type=gha,scope=llm-e2e
-          cache-to: type=gha,scope=llm-e2e,mode=max
-          build-args: GO_VERSION=1.25
-
       - name: Set up Helm
-        if: ${{ github.event_name == 'pull_request' }}
         uses: azure/setup-helm@v4
         with:
           version: v3.14.4
 
-      - name: Log in to GHCR for Helm
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          set -euo pipefail
-          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-
       - name: Build chart dependencies
-        if: ${{ github.event_name == 'pull_request' }}
         run: helm dependency build "$CHART_DIR"
 
       - name: Lint chart
-        if: ${{ github.event_name == 'pull_request' }}
         run: helm lint "$CHART_DIR" --set llm.databaseUrl.value=dummy
 
-      - name: Package PR chart
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          helm package "$CHART_DIR" \
-            --destination dist \
-            --version "${{ steps.artifact.outputs.chart_version }}" \
-            --app-version "${{ steps.artifact.outputs.chart_version }}"
-
-      - name: Push PR chart
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          set -euo pipefail
-          chart_name="$(basename "$CHART_DIR")"
-          helm push "dist/${chart_name}-${{ steps.artifact.outputs.chart_version }}.tgz" "$CHART_REGISTRY"
-
-      - name: Provision cluster with PR artifact
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: agynio/bootstrap/.github/actions/provision@main
-        env:
-          TF_VAR_llm_chart_version: ${{ steps.artifact.outputs.chart_version }}
-          TF_VAR_llm_image_tag: ${{ steps.artifact.outputs.image_tag }}
-
       - name: Provision cluster
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -26,7 +26,7 @@ functions:
     fi
   patch_deployment: |-
     deployment=$(kubectl get deployment -n ${LLM_NAMESPACE} \
-      -l app.kubernetes.io/name=llm,app.kubernetes.io/instance=llm \
+      -l app.kubernetes.io/name=llm \
       -o jsonpath='{.items[0].metadata.name}')
     if [ -z "$deployment" ]; then
       echo "ERROR: LLM deployment not found in namespace ${LLM_NAMESPACE}" >&2
@@ -113,8 +113,8 @@ pipelines:
           sleep 2
         done
         if [ "$healthy" != "true" ]; then
-          kubectl get pods -n ${LLM_NAMESPACE} -l app.kubernetes.io/name=llm,app.kubernetes.io/instance=llm -o wide >&2
-          kubectl logs -n ${LLM_NAMESPACE} -l app.kubernetes.io/name=llm,app.kubernetes.io/instance=llm --tail=200 >&2
+          kubectl get pods -n ${LLM_NAMESPACE} -l app.kubernetes.io/name=llm -o wide >&2
+          kubectl logs -n ${LLM_NAMESPACE} -l app.kubernetes.io/name=llm --tail=200 >&2
           echo "ERROR: LLM did not become healthy within 120s" >&2
           exit 1
         fi
@@ -136,7 +136,6 @@ dev:
     namespace: ${LLM_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: llm
-      app.kubernetes.io/instance: llm
     containers:
       llm:
         container: llm


### PR DESCRIPTION
Swaps provisioning to `agynio/e2e/.github/actions/provision-vm`.

llm is the only repo that fed a PR-built chart to the provisioner via `TF_VAR_llm_chart_version`. The VM has no per-service chart pin — the umbrella owns subchart versions — so the image/chart publish chain is removed. `helm lint` stays. The job already deployed from source with devspace and tested that, so what the E2E actually covers is unchanged.

Also drops `app.kubernetes.io/instance` from the dev selector: the platform is a single Helm release on the VM.