### PR TITLE
Give codex the auth file a ChatGPT-mode CLI will start on

### DIFF
--- a/internal/grpcserver/codexauth.go
+++ b/internal/grpcserver/codexauth.go
@@ -1,0 +1,51 @@
+package grpcserver
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// A ChatGPT-mode codex refuses to start without this file, and parses it before
+// it ever reaches the network. The id_token is a syntactically valid RS256 JWT
+// whose claim set is empty -- enough to be decoded, and carrying nothing. Every
+// credential field is blank on purpose: the proxy builds the upstream header
+// from the resolved subscription, so anything here would be dead weight the
+// container had no business holding.
+const codexPlaceholderIDToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.e30." +
+	"upI8kdqCUNUUgd1IrUpjNDDiif7yJZT_pI03g_DW6-aFIxEZD_kszt6E33_cjiUv6tWkutqTDgLr8XfKzFVfBKUTA9QDhpY9" +
+	"Imavnu-CW5k6xSUdiSiwo5b7EyMGBO7bRPN9b0L3OL2CzqowqOalYiqY0lldy1IDUgD_n5Cm0CFLpMOipb_vGf2KJFYmR8T_" +
+	"oZOAJzf6FYbZKFhjujeXiVLah2kj2qIZMIws9Q5t485udznl_gNlQwcnVB3bqEd6_msgUOo0ZRkyctQz9rZ70-JBviwXzhiq" +
+	"oeDGeiqJeRbaWLOjhmpWlwc6DJgRgP1H59dzV9htOWjST6cs8vpG2A"
+
+type codexAuth struct {
+	AuthMode     string          `json:"auth_mode"`
+	OpenAIAPIKey *string         `json:"OPENAI_API_KEY"`
+	Tokens       codexAuthTokens `json:"tokens"`
+	LastRefresh  string          `json:"last_refresh"`
+}
+
+type codexAuthTokens struct {
+	IDToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	AccountID    string `json:"account_id"`
+}
+
+// codexPlaceholderAuth stamps last_refresh at the moment the attachment is
+// served, which is workload assembly. A fixed timestamp would age into codex
+// treating the credential as stale and refreshing it -- against an auth host
+// the platform does not intercept, so the refresh fails and takes the CLI with
+// it. Freshly stamped, nothing tries.
+func codexPlaceholderAuth(now time.Time) string {
+	payload, err := json.Marshal(codexAuth{
+		AuthMode: "chatgpt",
+		Tokens: codexAuthTokens{
+			IDToken: codexPlaceholderIDToken,
+		},
+		LastRefresh: now.UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return ""
+	}
+	return string(payload)
+}

--- a/internal/grpcserver/codexauth_test.go
+++ b/internal/grpcserver/codexauth_test.go
@@ -1,0 +1,64 @@
+package grpcserver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCodexPlaceholderAuthShape(t *testing.T) {
+	now := time.Date(2026, 8, 9, 16, 59, 35, 0, time.UTC)
+
+	var auth codexAuth
+	if err := json.Unmarshal([]byte(codexPlaceholderAuth(now)), &auth); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if auth.AuthMode != "chatgpt" {
+		t.Fatalf("auth_mode = %q", auth.AuthMode)
+	}
+	if auth.OpenAIAPIKey != nil {
+		t.Fatalf("OPENAI_API_KEY = %v, want null", *auth.OpenAIAPIKey)
+	}
+	if auth.Tokens.IDToken == "" {
+		t.Fatal("id_token is empty")
+	}
+	// Blank on purpose: the proxy builds the upstream header from the resolved
+	// subscription, so a real credential here would be dead weight.
+	if auth.Tokens.AccessToken != "" || auth.Tokens.RefreshToken != "" || auth.Tokens.AccountID != "" {
+		t.Fatalf("credential fields not blank: %+v", auth.Tokens)
+	}
+	if auth.LastRefresh != "2026-08-09T16:59:35Z" {
+		t.Fatalf("last_refresh = %q", auth.LastRefresh)
+	}
+}
+
+// codex decodes the token before it reaches the network, so it has to be a
+// real JWT -- three segments, and a claim set that parses.
+func TestCodexPlaceholderIDTokenDecodes(t *testing.T) {
+	segments := strings.Split(codexPlaceholderIDToken, ".")
+	if len(segments) != 3 {
+		t.Fatalf("segments = %d, want 3", len(segments))
+	}
+	for _, segment := range segments[:2] {
+		decoded, err := base64.RawURLEncoding.DecodeString(segment)
+		if err != nil {
+			t.Fatalf("decode %q: %v", segment, err)
+		}
+		var claims map[string]any
+		if err := json.Unmarshal(decoded, &claims); err != nil {
+			t.Fatalf("parse %s: %v", decoded, err)
+		}
+	}
+}
+
+// A fixed timestamp would age into codex treating the credential as stale and
+// refreshing it against a host the platform does not intercept.
+func TestCodexPlaceholderAuthStampsEachCall(t *testing.T) {
+	first := codexPlaceholderAuth(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	second := codexPlaceholderAuth(time.Date(2026, 8, 9, 0, 0, 0, 0, time.UTC))
+	if first == second {
+		t.Fatal("last_refresh did not follow the clock")
+	}
+}

--- a/internal/grpcserver/subscriptions.go
+++ b/internal/grpcserver/subscriptions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	llmv1 "github.com/agynio/llm/.gen/go/agynio/api/llm/v1"
 	"github.com/agynio/llm/internal/identity"
@@ -25,10 +26,12 @@ type vendorBinding struct {
 	// How the placeholder reaches the container, and what its writer needs. An
 	// env kind is the orchestrator's to set on the container spec; a file kind
 	// is agynd's to write at a path only it can resolve against HOME.
-	placeholderKind     llmv1.PlaceholderKind
-	placeholderEnv      string
-	placeholderPath     string
-	placeholderContents string
+	placeholderKind llmv1.PlaceholderKind
+	placeholderEnv  string
+	placeholderPath string
+	// Built per attachment rather than stored: the contents carry a timestamp
+	// the CLI reads as the credential's age.
+	placeholderContents func(time.Time) string
 }
 
 var vendorBindings = map[subscription.Vendor]vendorBinding{
@@ -51,7 +54,7 @@ var vendorBindings = map[subscription.Vendor]vendorBinding{
 		protocol:            llmv1.Protocol_PROTOCOL_RESPONSES,
 		placeholderKind:     llmv1.PlaceholderKind_PLACEHOLDER_KIND_FILE,
 		placeholderPath:     ".codex/auth.json",
-		placeholderContents: `{"OPENAI_API_KEY":null,"tokens":{"access_token":"agyn-placeholder-not-a-credential","account_id":"agyn-placeholder"},"last_refresh":"2026-01-01T00:00:00Z"}`,
+		placeholderContents: codexPlaceholderAuth,
 	},
 }
 
@@ -92,13 +95,15 @@ func toProtoSubscription(sub subscription.Subscription) *llmv1.Subscription {
 
 func toProtoAttachment(a subscription.Attachment) *llmv1.SubscriptionAttachment {
 	proto := &llmv1.SubscriptionAttachment{
-		Meta:           toProtoMeta(a.ID, a.CreatedAt, a.CreatedAt),
-		SubscriptionId: a.SubscriptionID.String(),
-		Vendor:         toProtoVendor(a.Vendor),
-		PlaceholderKind:     vendorBindings[a.Vendor].placeholderKind,
-		PlaceholderEnv:      vendorBindings[a.Vendor].placeholderEnv,
-		PlaceholderPath:     vendorBindings[a.Vendor].placeholderPath,
-		PlaceholderContents: vendorBindings[a.Vendor].placeholderContents,
+		Meta:            toProtoMeta(a.ID, a.CreatedAt, a.CreatedAt),
+		SubscriptionId:  a.SubscriptionID.String(),
+		Vendor:          toProtoVendor(a.Vendor),
+		PlaceholderKind: vendorBindings[a.Vendor].placeholderKind,
+		PlaceholderEnv:  vendorBindings[a.Vendor].placeholderEnv,
+		PlaceholderPath: vendorBindings[a.Vendor].placeholderPath,
+	}
+	if contents := vendorBindings[a.Vendor].placeholderContents; contents != nil {
+		proto.PlaceholderContents = contents(time.Now())
 	}
 	if a.AgentID != nil {
 		proto.Target = &llmv1.SubscriptionAttachment_AgentId{AgentId: a.AgentID.String()}


### PR DESCRIPTION
The `~/.codex/auth.json` placeholder was shaped for an API-key codex — no `auth_mode`, no `id_token`, and a fake access token. A subscription-mode CLI reads this file before it ever reaches the network and will not start on that.

```json
{
  "auth_mode": "chatgpt",
  "OPENAI_API_KEY": null,
  "tokens": { "id_token": "<empty-claim JWT>", "access_token": "", "refresh_token": "", "account_id": "" },
  "last_refresh": "<stamped when served>"
}
```

The `id_token` is a syntactically valid RS256 JWT whose claim set is `{}` — decodable, and carrying nothing. Every credential field is blank on purpose: the proxy builds the upstream header from the resolved subscription, so a real value here would be dead weight the container has no business holding.

`last_refresh` is stamped when the attachment is served — workload assembly — rather than fixed. A fixed timestamp ages into codex treating the credential as stale and refreshing it, and that refresh goes to an auth host the platform does not intercept: it fails, and takes the CLI with it. This is why `placeholderContents` became a `func(time.Time) string`.

Delivered through the existing file-placeholder path, so nothing else changes: `agynd` already writes this file in both agent and holder mode.