### PR TITLE
Stop deciding what a CLI's credential file looks like

### DIFF
--- a/internal/grpcserver/subscriptions.go
+++ b/internal/grpcserver/subscriptions.go
@@ -92,9 +92,9 @@ func toProtoSubscription(sub subscription.Subscription) *llmv1.Subscription {
 
 func toProtoAttachment(a subscription.Attachment) *llmv1.SubscriptionAttachment {
 	proto := &llmv1.SubscriptionAttachment{
-		Meta:           toProtoMeta(a.ID, a.CreatedAt, a.CreatedAt),
-		SubscriptionId: a.SubscriptionID.String(),
-		Vendor:         toProtoVendor(a.Vendor),
+		Meta:                toProtoMeta(a.ID, a.CreatedAt, a.CreatedAt),
+		SubscriptionId:      a.SubscriptionID.String(),
+		Vendor:              toProtoVendor(a.Vendor),
 		PlaceholderKind:     vendorBindings[a.Vendor].placeholderKind,
 		PlaceholderEnv:      vendorBindings[a.Vendor].placeholderEnv,
 		PlaceholderPath:     vendorBindings[a.Vendor].placeholderPath,


### PR DESCRIPTION
Drops `placeholder_path` and `placeholder_contents` from the OpenAI binding. `agynd` derives them instead — see [agynd-cli#178](https://github.com/agynio/agynd-cli/pull/178).

The table is keyed by vendor, but every value in it was determined by the CLI. `~/.codex/auth.json` and its `auth_mode` are Codex conventions, not OpenAI's; a different CLI talking to OpenAI would need neither. This service has no way to know which CLI a workload runs, and shouldn't — `agynd` reads that from `config.json`.

What stays is what actually belongs here: the subscription and its attachments, secret resolution, and the vendor facts the proxy needs — `upstream`, `protocol`, and the real token from `ResolveSubscription`.

`placeholder_kind`/`placeholder_env` remain for Anthropic, whose placeholder is an environment variable the orchestrator must put on the container spec for a sandbox shell to see. That is the one piece of CLI knowledge still outside `agynd`, and [architecture#175](https://github.com/agynio/architecture/pull/175) records both the gap and the way out.