### PR TITLE
Actually drop the CLI's file shape

### DIFF
--- a/internal/grpcserver/subscriptions.go
+++ b/internal/grpcserver/subscriptions.go
@@ -22,13 +22,12 @@ import (
 type vendorBinding struct {
 	upstream string
 	protocol llmv1.Protocol
-	// How the placeholder reaches the container, and what its writer needs. An
-	// env kind is the orchestrator's to set on the container spec; a file kind
-	// is agynd's to write at a path only it can resolve against HOME.
-	placeholderKind     llmv1.PlaceholderKind
-	placeholderEnv      string
-	placeholderPath     string
-	placeholderContents string
+	// How the placeholder reaches the container. Only the env kind is named
+	// here, and only because the orchestrator sets it on the container spec and
+	// has no way to know the CLI. A file kind is agynd's outright: its path and
+	// contents follow from the CLI, which this service never learns.
+	placeholderKind llmv1.PlaceholderKind
+	placeholderEnv  string
 }
 
 var vendorBindings = map[subscription.Vendor]vendorBinding{
@@ -43,15 +42,12 @@ var vendorBindings = map[subscription.Vendor]vendorBinding{
 	// latter is where an API-key Codex CLI goes, and pairing that host with a
 	// subscription credential is what made an earlier version incoherent.
 	//
-	// Its credential is read from a file, not an environment variable, so the
-	// placeholder is one agynd writes. The contents only have to be shaped
-	// enough for the CLI to start: the proxy replaces the header built from it.
+	// Its credential is read from a file whose path and shape are the Codex
+	// CLI's, not OpenAI's -- so agynd writes it, and nothing about it is
+	// declared here.
 	subscription.VendorOpenAI: {
-		upstream:            "https://chatgpt.com/backend-api/codex",
-		protocol:            llmv1.Protocol_PROTOCOL_RESPONSES,
-		placeholderKind:     llmv1.PlaceholderKind_PLACEHOLDER_KIND_FILE,
-		placeholderPath:     ".codex/auth.json",
-		placeholderContents: `{"OPENAI_API_KEY":null,"tokens":{"access_token":"agyn-placeholder-not-a-credential","account_id":"agyn-placeholder"},"last_refresh":"2026-01-01T00:00:00Z"}`,
+		upstream: "https://chatgpt.com/backend-api/codex",
+		protocol: llmv1.Protocol_PROTOCOL_RESPONSES,
 	},
 }
 
@@ -92,13 +88,11 @@ func toProtoSubscription(sub subscription.Subscription) *llmv1.Subscription {
 
 func toProtoAttachment(a subscription.Attachment) *llmv1.SubscriptionAttachment {
 	proto := &llmv1.SubscriptionAttachment{
-		Meta:                toProtoMeta(a.ID, a.CreatedAt, a.CreatedAt),
-		SubscriptionId:      a.SubscriptionID.String(),
-		Vendor:              toProtoVendor(a.Vendor),
-		PlaceholderKind:     vendorBindings[a.Vendor].placeholderKind,
-		PlaceholderEnv:      vendorBindings[a.Vendor].placeholderEnv,
-		PlaceholderPath:     vendorBindings[a.Vendor].placeholderPath,
-		PlaceholderContents: vendorBindings[a.Vendor].placeholderContents,
+		Meta:            toProtoMeta(a.ID, a.CreatedAt, a.CreatedAt),
+		SubscriptionId:  a.SubscriptionID.String(),
+		Vendor:          toProtoVendor(a.Vendor),
+		PlaceholderKind: vendorBindings[a.Vendor].placeholderKind,
+		PlaceholderEnv:  vendorBindings[a.Vendor].placeholderEnv,
 	}
 	if a.AgentID != nil {
 		proto.Target = &llmv1.SubscriptionAttachment_AgentId{AgentId: a.AgentID.String()}

--- a/internal/grpcserver/subscriptions_test.go
+++ b/internal/grpcserver/subscriptions_test.go
@@ -219,32 +219,23 @@ func TestCreateSubscriptionAcceptsTheDeprecatedVendorNames(t *testing.T) {
 	}
 }
 
-// Each vendor reports one delivery mechanism with everything its writer needs,
-// so neither the orchestrator nor agynd holds a vendor table of its own.
-func TestAttachmentReportsThePlaceholderItsWriterNeeds(t *testing.T) {
-	cases := []struct {
-		vendor   subscription.Vendor
-		kind     llmv1.PlaceholderKind
-		wantEnv  bool
-		wantFile bool
-	}{
-		{subscription.VendorAnthropic, llmv1.PlaceholderKind_PLACEHOLDER_KIND_ENV, true, false},
-		{subscription.VendorOpenAI, llmv1.PlaceholderKind_PLACEHOLDER_KIND_FILE, false, true},
+// Only the environment-variable kind is reported, and only because the
+// orchestrator sets it on the container spec without knowing the CLI. A
+// file-reading CLI is agynd's to serve outright.
+func TestAttachmentReportsOnlyTheVariableItsWriterNeeds(t *testing.T) {
+	anthropic := toProtoAttachment(subscription.Attachment{Vendor: subscription.VendorAnthropic})
+	if anthropic.GetPlaceholderKind() != llmv1.PlaceholderKind_PLACEHOLDER_KIND_ENV {
+		t.Fatalf("anthropic kind = %v", anthropic.GetPlaceholderKind())
 	}
-	for _, tc := range cases {
-		proto := toProtoAttachment(subscription.Attachment{Vendor: tc.vendor})
-		if proto.GetPlaceholderKind() != tc.kind {
-			t.Fatalf("%s placeholder kind = %v, want %v", tc.vendor, proto.GetPlaceholderKind(), tc.kind)
-		}
-		if (proto.GetPlaceholderEnv() != "") != tc.wantEnv {
-			t.Fatalf("%s placeholder_env = %q", tc.vendor, proto.GetPlaceholderEnv())
-		}
-		if (proto.GetPlaceholderPath() != "") != tc.wantFile {
-			t.Fatalf("%s placeholder_path = %q", tc.vendor, proto.GetPlaceholderPath())
-		}
-		if (proto.GetPlaceholderContents() != "") != tc.wantFile {
-			t.Fatalf("%s placeholder_contents = %q", tc.vendor, proto.GetPlaceholderContents())
-		}
+	if anthropic.GetPlaceholderEnv() == "" {
+		t.Fatal("anthropic placeholder_env is empty")
+	}
+
+	// Nothing about the Codex CLI's auth.json is this service's to declare.
+	openai := toProtoAttachment(subscription.Attachment{Vendor: subscription.VendorOpenAI})
+	if openai.GetPlaceholderPath() != "" || openai.GetPlaceholderContents() != "" {
+		t.Fatalf("openai still declares a file: path=%q contents=%q",
+			openai.GetPlaceholderPath(), openai.GetPlaceholderContents())
 	}
 }
 


### PR DESCRIPTION
[#54](https://github.com/agynio/llm/pull/54) was supposed to do this and did not — the edit was written against a branch that had already been discarded, so every replacement silently matched nothing and the PR merged as a gofmt reflow. The table kept declaring `.codex/auth.json` and its contents.

This removes them for real: `placeholderPath` and `placeholderContents` are gone from the binding and from `toProtoAttachment`, verified by a test that asserts OpenAI declares no file.

`placeholderKind`/`placeholderEnv` stay for Anthropic — the orchestrator sets that variable on the container spec and has no way to know the CLI. That remains the one piece of CLI knowledge outside `agynd`.

`agynd` already derives the file itself as of [agynd-cli#178](https://github.com/agynio/agynd-cli/pull/178), and the orchestrator stopped relaying it in [agents-orchestrator#257](https://github.com/agynio/agents-orchestrator/pull/257) — both of which did land correctly, so behaviour is unaffected either way. This is the dead declaration catching up.