### PR TITLE
Forward codex to the origin, not to a path twice

### DIFF
--- a/internal/grpcserver/subscriptions.go
+++ b/internal/grpcserver/subscriptions.go
@@ -45,8 +45,12 @@ var vendorBindings = map[subscription.Vendor]vendorBinding{
 	// Its credential is read from a file whose path and shape are the Codex
 	// CLI's, not OpenAI's -- so agynd writes it, and nothing about it is
 	// declared here.
+	//
+	// The origin only. The proxy appends the caller's own path, and the CLI
+	// already addresses /backend-api/codex/responses -- carrying that prefix
+	// here too would forward it twice.
 	subscription.VendorOpenAI: {
-		upstream: "https://chatgpt.com/backend-api/codex",
+		upstream: "https://chatgpt.com",
 		protocol: llmv1.Protocol_PROTOCOL_RESPONSES,
 	},
 }


### PR DESCRIPTION
`https://chatgpt.com/backend-api/codex` → `https://chatgpt.com`.

The proxy composes its target as `upstream + r.URL.RequestURI()`, and a subscription-mode codex already addresses `/backend-api/codex/responses`. With the prefix on the binding as well, that became:

```
https://chatgpt.com/backend-api/codex/backend-api/codex/responses
```

which the vendor answers as a 404 — indistinguishable from the endpoint not existing. Anthropic avoided it only because its upstream is a bare origin, which is the shape the forwarder assumes.

`UpstreamEndpoint` is used nowhere else — interception is by hostname and role attribute, not by this value. [llm-proxy#…](https://github.com/agynio/llm-proxy) carries a regression test for the composition.