### PR TITLE
Provision E2E on the platform VM

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,101 +8,39 @@ on:
 
 permissions:
   contents: read
-  packages: write
+  packages: read
+
+concurrency:
+  group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       CHART_DIR: charts/llm
-      CHART_REGISTRY: oci://ghcr.io/agynio/charts
-      IMAGE_NAME: ghcr.io/agynio/llm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Determine PR artifact versions
-        id: artifact
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          set -euo pipefail
-          base_version="$(grep '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}')"
-          chart_version="${base_version}-pr.${{ github.event.pull_request.number }}.${{ github.run_number }}.${{ github.run_attempt }}"
-          image_tag="pr-${{ github.event.pull_request.number }}-${{ github.sha }}"
-          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
-          echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Docker Buildx
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push PR image
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: ${{ env.IMAGE_NAME }}:${{ steps.artifact.outputs.image_tag }}
-          cache-from: type=gha,scope=llm-e2e
-          cache-to: type=gha,scope=llm-e2e,mode=max
-          build-args: GO_VERSION=1.25
-
+      # Ahead of the VM boot: a chart that does not render is worth ten seconds
+      # to find out, not the twenty minutes the rest of this job takes. Release
+      # is otherwise the first thing that lints it.
       - name: Set up Helm
-        if: ${{ github.event_name == 'pull_request' }}
         uses: azure/setup-helm@v4
         with:
           version: v3.14.4
 
-      - name: Log in to GHCR for Helm
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Lint chart
         run: |
           set -euo pipefail
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-
-      - name: Build chart dependencies
-        if: ${{ github.event_name == 'pull_request' }}
-        run: helm dependency build "$CHART_DIR"
-
-      - name: Lint chart
-        if: ${{ github.event_name == 'pull_request' }}
-        run: helm lint "$CHART_DIR" --set llm.databaseUrl.value=dummy
-
-      - name: Package PR chart
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          helm package "$CHART_DIR" \
-            --destination dist \
-            --version "${{ steps.artifact.outputs.chart_version }}" \
-            --app-version "${{ steps.artifact.outputs.chart_version }}"
-
-      - name: Push PR chart
-        if: ${{ github.event_name == 'pull_request' }}
-        run: |
-          set -euo pipefail
-          chart_name="$(basename "$CHART_DIR")"
-          helm push "dist/${chart_name}-${{ steps.artifact.outputs.chart_version }}.tgz" "$CHART_REGISTRY"
-
-      - name: Provision cluster with PR artifact
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: agynio/bootstrap/.github/actions/provision@main
-        env:
-          TF_VAR_llm_chart_version: ${{ steps.artifact.outputs.chart_version }}
-          TF_VAR_llm_image_tag: ${{ steps.artifact.outputs.image_tag }}
+          helm dependency build "$CHART_DIR"
+          helm lint "$CHART_DIR" --set llm.databaseUrl.value=dummy
 
       - name: Provision cluster
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v2beta1
 
 vars:
-  LLM_NAMESPACE: platform
+  LLM_NAMESPACE: agyn-platform
 
 functions:
   disable_argocd_sync: |-


### PR DESCRIPTION
`run-tests` reads `AGYN_API_TOKEN` from the environment; only the VM provisioner exports it. The bootstrap action left Terraform state behind instead, so every run since has died before a single test ran.

**The PR artifact block goes with it.** It built and pushed an image and a chart to GHCR on every pull request, and the only consumer was `TF_VAR_llm_chart_version` / `TF_VAR_llm_image_tag` on the bootstrap provision step — per-service chart pins do not exist on the VM path. The tests always ran against the source build DevSpace deploys, not the published artifact, so nothing they cover changes; the PR no longer publishes to GHCR.

The chart lint stays, moved ahead of the VM boot so a chart that does not render fails in ten seconds rather than twenty minutes. Without it, `release.yml` would be the first thing to render the chart.

**Namespace.** DevSpace follows the install to `agyn-platform`, which it moved to on 2026-08-09.

Depends on agynio/e2e#255.